### PR TITLE
Length operator; Tag body parsing fixes

### DIFF
--- a/lib/greenbar/engine.ex
+++ b/lib/greenbar/engine.ex
@@ -15,11 +15,17 @@ defmodule Greenbar.Engine do
     {:ok, engine}
   end
 
+  if Mix.env == :test do
+    def parse(%__MODULE__{}=engine, source) do
+      :gb_parser.scan_and_parse(source, engine)
+    end
+  end
+
   def compile!(%__MODULE__{}=engine, name, source, opts \\ []) do
     source = Enum.join([String.trim(source), "\n"])
     hash = :crypto.hash(:sha256, source) |> Base.encode16(case: :lower)
     if should_compile?(engine, name, hash, opts) do
-      case :gb_parser.scan_and_parse(source) do
+      case :gb_parser.scan_and_parse(source, engine) do
         {:ok, parsed} ->
           {_, opts} = Keyword.pop(opts, :force)
           template = Template.compile!(name, parsed, opts)

--- a/lib/greenbar/tag.ex
+++ b/lib/greenbar/tag.ex
@@ -73,7 +73,8 @@ defmodule Greenbar.Tag do
   ```
   defmodule MyApp.Tags.HelloWorld do
 
-    use Greenbar.Tag, name: "hello_world",
+    use Greenbar.Tag, name: "hello_world", # This would default to "helloworld"
+                                           # if not overridden here
                       body: false
 
     # Emits "hello, world" into template output buffer

--- a/lib/greenbar/tag.ex
+++ b/lib/greenbar/tag.ex
@@ -112,9 +112,13 @@ defmodule Greenbar.Tag do
 
   def render!(tag_id, tag_mod, attrs, scope, buffer) when is_map(scope) and is_list(buffer) do
     case tag_mod.render(tag_id, attrs, scope) do
-      {action, scope} when action in [:again, :halt, :once] ->
+      {action, scope, _body_scope} when action in [:again, :once] ->
         {scope, buffer}
-      {action, output, scope} when action in [:again, :halt, :once] ->
+      {action, output, scope, _body_scope} when action in [:again, :once] ->
+        {scope, Runtime.add_tag_output!(output, buffer, tag_mod)}
+      {:halt, scope} ->
+        {scope, buffer}
+      {:halt, output, scope} ->
         {scope, Runtime.add_tag_output!(output, buffer, tag_mod)}
       {:error, reason} ->
         raise_eval_error(reason)

--- a/lib/greenbar/tag.ex
+++ b/lib/greenbar/tag.ex
@@ -42,22 +42,31 @@ defmodule Greenbar.Tag do
   The tag's body content -- all template content ocurring between the tag and its matching `end` statement --
   will be evaluated none, one, or multiple times depending on the value the tag returns from its `render/2` function.
 
+  It is mandatory that tags use the `body?/0` callback to indicate when they expect body content. `false` indicates
+  the tag expects no content; `true` indicates it does. The default implementation returns `false`.
+
 
   # Controlling Template Execution
 
   Tags can control template execution by the value returned from `render/2`.
 
+  These return values are always valid:
   * `{:halt, scope}` -- the tag has completed and the template should continue processing.
   * `{:halt, output, scope}` -- the tag has completed and generated output. The output will be written
     to the render buffer before processing the rest of the template.
+  * `{:error, reason}` -- abort template execution and raise `Greenbar.EvaluationError`. `reason`, or a
+    its textual version, will be stored in the error's `message` field.
+
+  These return values are valid when a tag has body content:
   * `{:again, scope, body_scope}` -- execution should return to the tag after evaluating it's body.
     This return value is treated as `{:halt, scope}` when the tag lacks body content.
   * `{:once, scope, body_scope}` -- template execution should proceed after evaluating the tag's body
     exactly once. This return value is treated as `{:halt, scope}` when the tag lacks body content.
-  * `{:again | :once, output, scope, body_scope}` -- identical to the output-less versions above except
+  * `{[:again | :once], output, scope, body_scope}` -- identical to the output-less versions above except
     `output` is written to the render buffer before continuing.
-  * `{:error, reason}` -- abort template execution and raise `Greenbar.EvaluationError`. `reason`, or a
-    its textual version, will be stored in the error's `message` field.
+
+  Returning the wrong response type, ie. returning a body response when a tag has no body, will raise a
+  `Greenbar.EvaluationError` at runtime.
 
   """
 

--- a/lib/greenbar/tags/break.ex
+++ b/lib/greenbar/tags/break.ex
@@ -30,9 +30,8 @@ defmodule Greenbar.Tags.Break do
   ```
   """
 
-  use Greenbar.Tag
+  use Greenbar.Tag, name: "br"
 
-  def name, do: "br"
 
   def render(_id, _attrs, scope) do
     {:halt, %{name: :newline}, scope}

--- a/lib/greenbar/tags/count.ex
+++ b/lib/greenbar/tags/count.ex
@@ -28,7 +28,6 @@ defmodule Greenbar.Tags.Count do
 
   use Greenbar.Tag
 
-  def name, do: "count"
 
   def render(_id, attrs, scope) do
     case get_attr(attrs, "var") do

--- a/lib/greenbar/tags/each.ex
+++ b/lib/greenbar/tags/each.ex
@@ -33,13 +33,9 @@ defmodule Greenbar.Tags.Each do
 
   @remaining_key "__remaining__"
 
-  use Greenbar.Tag
+  use Greenbar.Tag, body: true
 
   alias Piper.Common.Scope.Scoped
-
-  def name, do: "each"
-
-  def body?, do: true
 
   def render(id, attrs, scope) do
     key = make_tag_key(id, @remaining_key)

--- a/lib/greenbar/tags/each.ex
+++ b/lib/greenbar/tags/each.ex
@@ -39,6 +39,8 @@ defmodule Greenbar.Tags.Each do
 
   def name, do: "each"
 
+  def body?, do: true
+
   def render(id, attrs, scope) do
     key = make_tag_key(id, @remaining_key)
     case get_remaining(scope, key, attrs) do

--- a/lib/greenbar/tags/if.ex
+++ b/lib/greenbar/tags/if.ex
@@ -33,11 +33,7 @@ defmodule Greenbar.Tags.If do
 
   """
 
-  use Greenbar.Tag
-
-  def name, do: "if"
-
-  def body?, do: true
+  use Greenbar.Tag, body: true
 
   def render(_id, attrs, scope) do
     if get_attr(attrs, "cond", false) do

--- a/lib/greenbar/tags/if.ex
+++ b/lib/greenbar/tags/if.ex
@@ -37,6 +37,8 @@ defmodule Greenbar.Tags.If do
 
   def name, do: "if"
 
+  def body?, do: true
+
   def render(_id, attrs, scope) do
     if get_attr(attrs, "cond", false) do
       {:once, scope, new_scope(scope)}

--- a/lib/greenbar/tags/json.ex
+++ b/lib/greenbar/tags/json.ex
@@ -27,8 +27,6 @@ defmodule Greenbar.Tags.Json do
   """
   use Greenbar.Tag
 
-  def name, do: "json"
-
   def render(_id, attrs, scope) do
     case get_attr(attrs, "var") do
       nil ->

--- a/src/gb_expr_lexer.xrl
+++ b/src/gb_expr_lexer.xrl
@@ -13,11 +13,14 @@ LESS_THAN               = <
 LESS_THAN_EQ            = <\=
 EQ                      = \=\=
 NEQ                     = !\=
+LENGTH                  = length
 EMPTY                   = empty\?
 NOT_EMPTY               = not_empty\?
 BOUND                   = bound\?
+NOT_BOUND               = not_bound\?
 DOT                     = \.
 BRACKET                 = \[|\]
+PAREN                   = \(|\)
 SKIPPED                 = \s
 
 Rules.
@@ -37,9 +40,11 @@ Rules.
 {EMPTY}                 : {token, {empty, TokenLine, <<"empty?">>}}.
 {NOT_EMPTY}             : {token, {not_empty, TokenLine, <<"not_empty?">>}}.
 {BOUND}                 : {token, {bound, TokenLine, <<"bound?">>}}.
+{NOT_BOUND}             : {token, {not_bound, TokenLine, <<"not_bound?">>}}.
 {ASSIGN}                : {token, {assign, TokenLine, <<"=">>}}.
 {DOT}                   : {token, {dot, TokenLine, <<".">>}}.
 {BRACKET}               : {token, which_bracket(TokenLine, TokenChars)}.
+{PAREN}                 : {token, which_paren(TokenLine, TokenChars)}.
 {SKIPPED}               : skip_token.
 
 Erlang code.
@@ -63,3 +68,8 @@ which_bracket(TokenLine, [$[]) ->
   {lbracket, TokenLine, <<"[">>};
 which_bracket(TokenLine, [$]]) ->
   {rbracket, TokenLine, <<"]">>}.
+
+which_paren(TokenLine, [$(]) ->
+  {lparen, TokenLine, <<"(">>};
+which_paren(TokenLine, [$)]) ->
+  {rparen, TokenLine, <<")">>}.

--- a/test/eval_test.exs
+++ b/test/eval_test.exs
@@ -162,7 +162,7 @@ defmodule Greenbar.EvalTest do
     result = eval_template(context.engine, "bound_check", Templates.bound_check, %{})
     assert result === [%{name: :text, text: "No user creators available."}]
     result = eval_template(context.engine, "bound_check", Templates.bound_check, %{"user_creators" => [1,2]})
-    assert result == [%{name: :text, text: "There are 2 user_creator(s) available."}]
+    assert result == [%{name: :text, text: "2 user creator(s) available."}]
   end
 
 end

--- a/test/eval_test.exs
+++ b/test/eval_test.exs
@@ -112,13 +112,14 @@ defmodule Greenbar.EvalTest do
                                                                                                     "users" => [%{"name" => "Big Bird"}]},
                                                                                                   %{"name" => "accounting",
                                                                                                     "users" => [%{"name" => "The Count"}]}]})
+
     assert result === [%{children: [%{children: [%{name: :text, text: "admins"}, %{name: :newline}],
                                       name: :list_item}], name: :unordered_list},
                        %{children: [%{children: [%{name: :text, text: "Big Bird"}, %{name: :newline}],
                                       name: :list_item}], name: :ordered_list},
                        %{children: [%{children: [%{name: :text, text: "accounting"},
                                                  %{name: :newline}], name: :list_item}], name: :unordered_list},
-                       %{children: [%{children: [%{name: :text, text: "accounting"},
+                       %{children: [%{children: [%{name: :text, text: "The Count"},
                                                  %{name: :newline}], name: :list_item}],
                          name: :ordered_list}]
   end
@@ -141,6 +142,27 @@ defmodule Greenbar.EvalTest do
                        %{name: :text, text: "Enabled Version: 0.0.3"}, %{name: :newline},
                        %{name: :text, text: "Relay Groups: preprod"}, %{name: :newline},
                        %{name: :text, text: "prod"}]
+  end
+
+  test "length check works", context do
+    result = eval_template(context.engine, "length_test", Templates.length_test, %{"pets" => %{"cats" => [1,2]}})
+    assert result === [%{name: :text, text: "No puppies :("}]
+    result = eval_template(context.engine, "length_test", Templates.length_test, %{"pets" => %{"cats" => [1,2],
+                                                                                               "puppies" => []}})
+    assert result === [%{name: :text, text: "No puppies :("}]
+    result = eval_template(context.engine, "length_test", Templates.length_test, %{"pets" => %{"cats" => [1,2],
+                                                                                               "puppies" => [1]}})
+    assert result === [%{name: :text, text: "One puppy"}]
+    result = eval_template(context.engine, "length_test", Templates.length_test, %{"pets" => %{"cats" => [1,2],
+                                                                                               "puppies" => [1,2,3]}})
+    assert result === [%{name: :text, text: "Lots of puppies!"}]
+  end
+
+  test "bound check works", context do
+    result = eval_template(context.engine, "bound_check", Templates.bound_check, %{})
+    assert result === [%{name: :text, text: "No user creators available."}]
+    result = eval_template(context.engine, "bound_check", Templates.bound_check, %{"user_creators" => [1,2]})
+    assert result == [%{name: :text, text: "There are 2 user_creator(s) available."}]
   end
 
 end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -1,38 +1,42 @@
 defmodule Greenbar.ParserTest do
 
-  alias :gb_parser, as: Parser
-
   use Greenbar.Test.Support.TestCase
 
-  test "text parses as text" do
-    {:ok, template} = Parser.scan_and_parse("This is a test.")
+  setup_all do
+    {:ok, engine} = Engine.new
+    [engine: engine]
+  end
+
+
+  test "text parses as text", context do
+    {:ok, template} = Engine.parse(context.engine, "This is a test.")
     {:text, "This is a test."} = Enum.at(template, 0)
   end
 
-  test "newlines stay with their parsed text" do
-    {:ok, template} = Parser.scan_and_parse("This is a \ntest.\n")
+  test "newlines stay with their parsed text", context do
+    {:ok, template} = Engine.parse(context.engine, "This is a \ntest.\n")
     assert Enum.count(template) == 1
     text_node = Enum.at(template, 0)
     assert text_node == {:text, "This is a \ntest.\n"}
   end
 
-  test "tags w/o bodies are parsed" do
-    {:ok, template} = Parser.scan_and_parse("~title text=\"Hello\" ~")
+  test "tags w/o bodies are parsed", context do
+    {:ok, template} = Engine.parse(context.engine, "~count var=$foo~")
     assert Enum.count(template) == 1
-    {:tag, "title", attrs, nil} = Enum.at(template, 0)
-    assert [{:assign_tag_attr, "text", {:string, 1, "\"Hello\""}}] == attrs
+    {:tag, "count", attrs, nil} = Enum.at(template, 0)
+    assert [{:assign_tag_attr, "var", {:var, "foo", nil}}] == attrs
   end
 
-  test "tags w/bodies are parsed" do
-    {:ok, template} = Parser.scan_and_parse(Templates.vm_list)
+  test "tags w/bodies are parsed", context do
+    {:ok, template} = Engine.parse(context.engine, Templates.vm_list)
     assert Enum.count(template) == 1
     {:tag, "each", attrs, body} = Enum.at(template, 0)
     assert [{:assign_tag_attr, "var", {:var, "vms", nil}}] == attrs
     assert [{:var, "item", [key: "name"]}, {:text, "\n"}] == body
   end
 
-  test "nested tags are parsed" do
-    {:ok, template} = Parser.scan_and_parse(Templates.vms_per_region)
+  test "nested tags are parsed", context do
+    {:ok, template} = Engine.parse(context.engine, Templates.vms_per_region)
     assert Enum.count(template) == 1
     {:tag, "each", attrs, body} = Enum.at(template, 0)
     assert [{:assign_tag_attr, "var", {:var, "regions", nil}}] == attrs
@@ -43,14 +47,13 @@ defmodule Greenbar.ParserTest do
             {:var, "item", [key: "id"]}, {:text, ")\n  "}] == body
   end
 
-  test "solo variables are parsed" do
-    {:ok, template} = Parser.scan_and_parse(Templates.solo_variable)
+  test "solo variables are parsed", context do
+    {:ok, template} = Engine.parse(context.engine, Templates.solo_variable)
     [{:text, "This is a test.\n"}, {:var, "item", nil}, {:text, ".\n"}] = template
   end
 
-  test "comments w/o terminating newlines are parsed" do
-    {:ok, engine} = Greenbar.Engine.new()
-    Greenbar.Engine.compile!(engine, "dangling_comment", Templates.dangling_comment)
+  test "comments w/o terminating newlines are parsed", context do
+    Greenbar.Engine.compile!(context.engine, "dangling_comment", Templates.dangling_comment)
   end
 
 end

--- a/test/support/templates.ex
+++ b/test/support/templates.ex
@@ -92,7 +92,18 @@ The following users can help you right here in chat:
 ~end~
 ~end~
 """
-    end
+  end
+
+  def bound_check do
+    """
+~if cond=$user_creators not_bound?~
+No user creators available.
+~end~
+~if cond=$user_creators bound?~
+~count var=$user_creators~ user creator(s) available.
+~end~
+"""
+  end
 
   def simple_list do
     """
@@ -150,6 +161,20 @@ Versions: ~each var=$results[0].versions~
 Enabled Version: ~$results[0].enabled_version.version~
 Relay Groups: ~each var=$results[0].relay_groups~
 ~$item.name~
+~end~
+"""
+  end
+
+  def length_test do
+    """
+~if cond=length($pets.puppies) > 1~
+Lots of puppies!
+~end~
+~if cond=length($pets.puppies) == 1~
+One puppy
+~end~
+~if cond=length($pets.puppies) == 0~
+No puppies :(
 ~end~
 """
   end

--- a/test/support/test_case.ex
+++ b/test/support/test_case.ex
@@ -6,6 +6,7 @@ defmodule Greenbar.Test.Support.TestCase do
 
         alias Greenbar.Test.Support.Assertions
         alias Greenbar.Test.Support.Templates
+        alias Greenbar.Engine
 
         use ExUnit.Case
 


### PR DESCRIPTION
This PR adds:

* A general mechanism for calling arbitrary Elixir functions from Greenbar templates. `length` is implemented on top of this.
* Template lexing requires an instance of `Greenbar.Engine` which is used to distinguish between tags and non-tags and between non-body and body tags. Tags are now required to indicate whether or not they expect a body via the `body?/0` callback.
* Tightened up logic around processing return values from `render/3` to raise `Greenbar.EvaluationError` when response type and tag type (body vs. non-body) doesn't match.
* Updated `Greenbar.Tag` module doc to reflect the above changes.