### PR TITLE
Rudimentary "join" tag

### DIFF
--- a/lib/greenbar/engine.ex
+++ b/lib/greenbar/engine.ex
@@ -2,7 +2,7 @@ defmodule Greenbar.Engine do
 
   @default_tags [Greenbar.Tags.Count, Greenbar.Tags.Each,
                  Greenbar.Tags.Break, Greenbar.Tags.If,
-                 Greenbar.Tags.Json]
+                 Greenbar.Tags.Json, Greenbar.Tags.Join]
 
   defstruct [tags: %{}, templates: %{}]
 

--- a/lib/greenbar/tags/join.ex
+++ b/lib/greenbar/tags/join.ex
@@ -3,11 +3,9 @@ defmodule Greenbar.Tags.Join do
   @remaining_key "__remaining__"
   @downstream_key "__downstream__"
 
-  use Greenbar.Tag
+  use Greenbar.Tag, body: true
 
   alias Piper.Common.Scope.Scoped
-
-  def name, do: "join"
 
   require Logger
   def render(id, attrs, scope) do

--- a/lib/greenbar/tags/join.ex
+++ b/lib/greenbar/tags/join.ex
@@ -1,0 +1,71 @@
+defmodule Greenbar.Tags.Join do
+
+  @remaining_key "__remaining__"
+  @downstream_key "__downstream__"
+
+  use Greenbar.Tag
+
+  alias Piper.Common.Scope.Scoped
+
+  def name, do: "join"
+
+  require Logger
+  def render(id, attrs, scope) do
+    remaining_key = make_tag_key(id, @remaining_key)
+    downstream_key = make_tag_key(id, @downstream_key)
+    {downstream, scope} = case Scoped.lookup(scope, downstream_key) do
+                            {:ok, _} ->
+                              {true, scope}
+                            _ ->
+                              {:ok, scope} = Scoped.set(scope, downstream_key, true)
+                              {false, scope}
+                          end
+    joiner = get_attr(attrs, "with", ", ")
+    case get_remaining(scope, remaining_key, attrs) do
+      nil ->
+        {:halt, scope}
+      [] ->
+        scope = scope
+        |> Scoped.erase(downstream_key)
+        |> Scoped.erase(remaining_key)
+        {:halt, scope}
+      [h|t] ->
+        var_name = get_attr(attrs, "as", "item")
+        child_scope = new_scope(scope)
+        {:ok, child_scope} = Scoped.set(child_scope, var_name, h)
+        {:ok, scope} = set_remaining(scope, remaining_key, t)
+
+        output = if downstream do
+          joiner
+        else
+          nil
+        end
+
+        {:again, output, scope, child_scope}
+    end
+  end
+
+  defp get_remaining(scope, key, attrs) do
+    case Scoped.lookup(scope, key) do
+      {:not_found, _} ->
+        case get_attr(attrs, "var") do
+          {:not_found, _} ->
+            nil
+          value ->
+            value
+        end
+      {:ok, value} ->
+        value
+    end
+  end
+
+  defp set_remaining(scope, key, remaining) do
+    case Scoped.update(scope, key, remaining) do
+      {:not_found, _} ->
+        Scoped.set(scope, key, remaining)
+      {:ok, scope} ->
+        {:ok, scope}
+    end
+  end
+
+end

--- a/test/greenbar/tags/join_test.exs
+++ b/test/greenbar/tags/join_test.exs
@@ -50,7 +50,6 @@ defmodule Greenbar.Tags.JoinTest do
     assert [%{name: :text, text: "highlander"}] == result
   end
 
-  @tag :skip # doesn't work just yet
   test "nested joins", context do
     result = eval_template(context.engine,
                            "nested",
@@ -59,6 +58,6 @@ defmodule Greenbar.Tags.JoinTest do
                                          ["four", "five", "six"],
                                          ["seven", "eight", "nine"]]})
 
-    assert [%{name: :text, text: "one, two, threeooofour, five, sixoooseven, eight, nineeeee"}] == result
+    assert [%{name: :text, text: "one, two, threeooofour, five, sixoooseven, eight, nine"}] == result
   end
 end

--- a/test/greenbar/tags/join_test.exs
+++ b/test/greenbar/tags/join_test.exs
@@ -1,0 +1,64 @@
+defmodule Greenbar.Tags.JoinTest do
+  use Greenbar.Test.Support.TestCase
+  alias Greenbar.Engine
+
+  setup_all do
+    {:ok, engine} = Engine.new
+    [engine: engine]
+  end
+
+  defp eval_template(engine, name, template, args) do
+    engine = Engine.compile!(engine, name, template)
+    Engine.eval!(engine, name, args)
+  end
+
+  test "simple join", context do
+    result = eval_template(context.engine,
+                           "simple_join",
+                           "~join var=$stuff~~$item~~end~",
+                           %{"stuff" => ["foo", "bar", "baz"]})
+
+    assert [%{name: :text, text: "foo, bar, baz"}] == result
+  end
+
+  test "simple join with non-default joiner", context do
+    result = eval_template(context.engine,
+                           "simple_join_with_joiner",
+                           "~join var=$stuff with=ooo ~~$item~~end~",
+                           %{"stuff" => ["foo", "bar", "baz"]})
+
+    assert [%{name: :text, text: "fooooobarooobaz"}] == result
+  end
+
+  test "join with a body", context  do
+    result = eval_template(context.engine,
+                           "join_with_body",
+                           "~join var=$stuff~~$item.name~~end~",
+                           %{"stuff" => [%{"name" => "larry"},
+                                         %{"name" => "moe"},
+                                         %{"name" => "curly"}]})
+
+    assert [%{name: :text, text: "larry, moe, curly"}] == result
+  end
+
+  test "join with single input", context do
+    result = eval_template(context.engine,
+                           "join_with_one_input",
+                           "~join var=$stuff~~$item~~end~",
+                           %{"stuff" => ["highlander"]})
+
+    assert [%{name: :text, text: "highlander"}] == result
+  end
+
+  @tag :skip # doesn't work just yet
+  test "nested joins", context do
+    result = eval_template(context.engine,
+                           "nested",
+                           "~join var=$stuff with=ooo~~join var=$item as=i~~$i~~end~~end~",
+                           %{"stuff" => [["one", "two", "three"],
+                                         ["four", "five", "six"],
+                                         ["seven", "eight", "nine"]]})
+
+    assert [%{name: :text, text: "one, two, threeooofour, five, sixoooseven, eight, nineeeee"}] == result
+  end
+end


### PR DESCRIPTION
This provides very basic "join" capabilities, allowing you to create
comma-delimited lists from list input.

For example, given a variable `stuff` containing `["foo", "bar",
"baz"]`, the template `~join var=$stuff~~$item~~end~` will generate the
string `"foo, bar, baz"~.

It also works with transformations of the list item, as
well (e.g. `~join var=$stuff~~$item.name~~end~`)

The implementation is essentially the `each` tag, but with additional
tracking of whether or not the item being processed is the first item,
or a subsequent one; the joiner text (defaulting to `", "`) is output
before processing any subsequent list items.

Currently the ability to override the joiner text is limited due to what
is acceptable as a tag attribute value. For instance, a bare
hyphen (`-`) is not legal, and a quoted hyphen (`"-"`) will result in
the quote marks being injected into the resulting text (yielding
`"foo"-"bar"-"baz"`).

Nested joins do not currently compile.