### PR TITLE
Removed leading EOL from tag bodies

### DIFF
--- a/src/gb_parser.yrl
+++ b/src/gb_parser.yrl
@@ -200,6 +200,8 @@ ensure_list(Value) -> [Value].
 
 drop_leading_eol({text, <<"\n">>}) -> [];
 drop_leading_eol([{text, <<"\n">>}|T]) -> T;
+drop_leading_eol([{text, <<$\n, Text/binary>>}|T]) ->
+  [{text, Text}|T];
 drop_leading_eol(V) ->
   V.
 

--- a/test/eval_test.exs
+++ b/test/eval_test.exs
@@ -112,7 +112,6 @@ defmodule Greenbar.EvalTest do
                                                                                                     "users" => [%{"name" => "Big Bird"}]},
                                                                                                   %{"name" => "accounting",
                                                                                                     "users" => [%{"name" => "The Count"}]}]})
-
     assert result === [%{children: [%{children: [%{name: :text, text: "admins"}, %{name: :newline}],
                                       name: :list_item}], name: :unordered_list},
                        %{children: [%{children: [%{name: :text, text: "Big Bird"}, %{name: :newline}],
@@ -120,8 +119,7 @@ defmodule Greenbar.EvalTest do
                        %{children: [%{children: [%{name: :text, text: "accounting"},
                                                  %{name: :newline}], name: :list_item}], name: :unordered_list},
                        %{children: [%{children: [%{name: :text, text: "The Count"},
-                                                 %{name: :newline}], name: :list_item}],
-                         name: :ordered_list}]
+                                                 %{name: :newline}], name: :list_item}], name: :ordered_list}]
   end
 
   test "multiple same-scope each loops work", context do
@@ -163,6 +161,34 @@ defmodule Greenbar.EvalTest do
     assert result === [%{name: :text, text: "No user creators available."}]
     result = eval_template(context.engine, "bound_check", Templates.bound_check, %{"user_creators" => [1,2]})
     assert result == [%{name: :text, text: "2 user creator(s) available."}]
+  end
+
+  test "building tables with each tag", context do
+    result = eval_template(context.engine, "each_table", Templates.table_with_each, %{"users" => [%{"first_name" => "Darth",
+                                                                                                    "last_name" => "Vader"},
+                                                                                                  %{"first_name" => "C3P0",
+                                                                                                    "last_name" => "Botston"},
+                                                                                                  %{"first_name" => "Jabba",
+                                                                                                    "last_name" => "Huttman"}]})
+    assert result === [%{children: [%{children: [%{children: [%{name: :text, text: "First Name"}],
+                                                   name: :table_cell},
+                                                 %{children: [%{name: :text, text: "Last Name"}], name: :table_cell},
+                                                 %{children: [%{name: :text, text: "Foo"}], name: :table_cell}],
+                                      name: :table_header},
+                                    %{children: [%{children: [%{name: :text, text: "Darth"}],
+                                                   name: :table_cell},
+                                                 %{children: [%{name: :text, text: "Vader"}], name: :table_cell},
+                                                 %{children: [%{name: :text, text: "Bar"}], name: :table_cell}],
+                                      name: :table_row},
+                                    %{children: [%{children: [%{name: :text, text: "C3P0"}], name: :table_cell},
+                                                 %{children: [%{name: :text, text: "Botston"}], name: :table_cell},
+                                                 %{children: [%{name: :text, text: "Bar"}], name: :table_cell}],
+                                      name: :table_row},
+                                    %{children: [%{children: [%{name: :text, text: "Jabba"}],
+                                                   name: :table_cell},
+                                                 %{children: [%{name: :text, text: "Huttman"}], name: :table_cell},
+                                                 %{children: [%{name: :text, text: "Bar"}], name: :table_cell}],
+                                      name: :table_row}], name: :table}]
   end
 
 end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -43,7 +43,7 @@ defmodule Greenbar.ParserTest do
     assert {:var, "item", [key: "name"]} = Enum.at(body, 0)
     {:tag, "each", attrs, body} = Enum.at(body, 2)
     assert [{:assign_tag_attr, "var", {:var, "item", [key: "vms"]}}] == attrs
-    assert [{:text, "\n    "}, {:var, "item", [key: "name"]}, {:text, " ("},
+    assert [{:text, "    "}, {:var, "item", [key: "name"]}, {:text, " ("},
             {:var, "item", [key: "id"]}, {:text, ")\n  "}] == body
   end
 

--- a/test/support/templates.ex
+++ b/test/support/templates.ex
@@ -140,8 +140,10 @@ No user creators available.
   def nested_lists do
     """
 ~each var=$groups as=group~
+
 * ~$group.name~
 ~each var=$group.users as=user~
+
   1. ~$user.name~
 ~end~
 ~end~
@@ -175,6 +177,16 @@ One puppy
 ~end~
 ~if cond=length($pets.puppies) == 0~
 No puppies :(
+~end~
+"""
+  end
+
+  def table_with_each do
+    """
+| First Name | Last Name | Foo |
+|---|---|---|
+~each var=$users as=user~
+| ~$user.first_name~ | ~$user.last_name~ | Bar |
 ~end~
 """
   end


### PR DESCRIPTION
Among others this allows constructing tables with the `each` tag to work as expected:

```
| Username | Full Name | Status|
|---|---|---|
~each var=$users as=user~
| ~$user.username~ | ~$user.first_name~ ~$user.last_name~ | ~$user.status |
~end~
```