### PR TITLE
Allow empty tag bodies; Quoted strings as attr names

### DIFF
--- a/lib/greenbar/tag.ex
+++ b/lib/greenbar/tag.ex
@@ -300,6 +300,8 @@ defmodule Greenbar.Tag do
                                     {body_scope, updated}
                                   updated when is_list(updated) ->
                                     {body_scope, updated}
+                                  nil ->
+                                    {body_scope, []}
                                 end
     case tag_mod.post_body(tag_id, tag_attrs, tag_scope, body_scope, body_buffer) do
       {:ok, tag_scope, updated_body_buffer} when is_list(updated_body_buffer) ->

--- a/lib/greenbar/tags/attachment.ex
+++ b/lib/greenbar/tags/attachment.ex
@@ -86,6 +86,9 @@ defmodule Greenbar.Tags.Attachment do
     {:ok, scope, Map.put(attachment, :children, children)}
   end
 
+  defp make_attachment(nil) do
+    make_attachment(%{})
+  end
   defp make_attachment(attrs) do
     {attachment, fields} = Enum.reduce(attrs, {%{}, []}, &(gen_attributes(&1, &2)))
     attachment

--- a/src/gb_parser.yrl
+++ b/src/gb_parser.yrl
@@ -10,7 +10,7 @@ assign empty not_empty gt gte lt lte equal not_equal bound not_bound.
 
 Nonterminals
 
-template template_exprs tag_attrs tag_attr var_value var_expr var_ops.
+template template_exprs tag_attrs tag_attr attr_name var_value var_expr var_ops.
 
 Rootsymbol template.
 
@@ -32,6 +32,10 @@ template_exprs ->
 template_exprs ->
   tag tag_attrs : make_tag('$1', '$2').
 template_exprs ->
+  body_tag expr_end : make_tag('$1', [], []).
+template_exprs ->
+  body_tag tag_attrs expr_end : make_tag('$1', '$2', []).
+template_exprs ->
   body_tag template_exprs expr_end : make_tag('$1', [], '$2').
 template_exprs ->
   body_tag tag_attrs template_exprs expr_end : make_tag('$1', '$2', '$3').
@@ -52,6 +56,10 @@ template_exprs ->
 template_exprs ->
   tag tag_attrs template_exprs : combine(make_tag('$1', '$2'), '$3').
 template_exprs ->
+  body_tag expr_end template_exprs : combine(make_tag('$1', [], []), drop_leading_eol('$3')).
+template_exprs ->
+  body_tag tag_attrs expr_end template_exprs : combine(make_tag('$1', '$2', []), drop_leading_eol('$4')).
+template_exprs ->
   body_tag template_exprs expr_end template_exprs : combine(make_tag('$1', [], '$2'), drop_leading_eol('$4')).
 template_exprs ->
   body_tag tag_attrs template_exprs expr_end template_exprs : combine(make_tag('$1', '$2', '$3'), drop_leading_eol('$5')).
@@ -66,17 +74,22 @@ tag_attrs ->
   tag_attr tag_attrs : combine('$1', '$2').
 
 tag_attr ->
-  expr_name assign integer : {assign_tag_attr, value_from('$1'), '$3'}.
+  attr_name assign integer : {assign_tag_attr, '$1', '$3'}.
 tag_attr ->
-  expr_name assign float : {assign_tag_attr, value_from('$1'), '$3'}.
+  attr_name assign float : {assign_tag_attr, '$1', '$3'}.
 tag_attr ->
-  expr_name assign string : {assign_tag_attr, value_from('$1'), '$3'}.
+  attr_name assign string : {assign_tag_attr, '$1', '$3'}.
 tag_attr ->
-  expr_name assign expr_name : {assign_tag_attr, value_from('$1'), name_to_string('$3')}.
+  attr_name assign expr_name : {assign_tag_attr, '$1', name_to_string('$3')}.
 tag_attr ->
-  expr_name assign var_value : {assign_tag_attr, value_from('$1'), '$3'}.
+  attr_name assign var_value : {assign_tag_attr, '$1', '$3'}.
 tag_attr ->
-  expr_name assign var_expr : {assign_tag_attr, value_from('$1'), '$3'}.
+  attr_name assign var_expr : {assign_tag_attr, '$1', '$3'}.
+
+attr_name ->
+  expr_name : value_from('$1').
+attr_name ->
+  string : value_from('$1').
 
 var_expr ->
   var_value gt integer : {gt, '$1', '$3'}.

--- a/test/greenbar/tags/attachment_test.exs
+++ b/test/greenbar/tags/attachment_test.exs
@@ -48,6 +48,47 @@ defmodule Greenbar.Tags.AttachmentTest do
               children: []}] == result
   end
 
+  test "attachment with empty body with other template content", context do
+    result = eval_template(context.engine, "attachment_no_body_more_content",
+      """
+~attachment~~end~
+~each var=$things as=thing~
+_~$thing~_
+~end~
+""", %{"things" => ["a","b","c","d"]})
+    assert [%{children: [], fields: [], name: :attachment}, %{name: :italics, text: "a"},
+            %{name: :newline}, %{name: :italics, text: "b"}, %{name: :newline},
+            %{name: :italics, text: "c"}, %{name: :newline}, %{name: :italics, text: "d"}] == result
+  end
+
+  test "attachment with empty body and attrs with other template content", context do
+    result = eval_template(context.engine, "attachment_no_body_attrs_more_content",
+      """
+~attachment color=red title="Testing 123"~
+~end~
+* One
+* Two
+* Three
+      """, %{})
+    assert [%{children: [], color: "red", fields: [], name: :attachment,
+              title: "Testing 123"},
+            %{children: [%{children: [%{name: :text, text: "One"}, %{name: :newline}],
+                           name: :list_item},
+                         %{children: [%{name: :text, text: "Two"}, %{name: :newline}],
+                           name: :list_item},
+                         %{children: [%{name: :text, text: "Three"}, %{name: :newline}],
+                           name: :list_item}], name: :unordered_list}] == result
+  end
+
+  test "string attachment attribute names", context do
+    result = eval_template(context.engine, "attachment_string_attrs",
+                           "~attachment \"Error Status\"=$error~~end~",
+                           %{"error" => "Network disconnect"})
+    assert [%{children: [],
+              fields: [%{short: false, title: "Error Status",
+                         value: "Network disconnect"}], name: :attachment}] == result
+  end
+
   test "attachment attributes", context do
     result = eval_template(context.engine,
                            "attachment_attrs",

--- a/test/greenbar/tags/attachment_test.exs
+++ b/test/greenbar/tags/attachment_test.exs
@@ -29,6 +29,17 @@ defmodule Greenbar.Tags.AttachmentTest do
   test "attachment with empty body", context do
     result = eval_template(context.engine,
                            "attachment_no_body",
+                           "~attachment~~end~",
+                           %{})
+
+    assert [%{name: :attachment,
+              fields: [],
+              children: []}] == result
+  end
+
+  test "attachment with empty body (newline before end)", context do
+    result = eval_template(context.engine,
+                           "attachment_no_body_newline",
                            "~attachment~\n~end~",
                            %{})
 
@@ -57,7 +68,6 @@ defmodule Greenbar.Tags.AttachmentTest do
               ]}] == result
   end
 
-  # Note: The assertion in this case is a little bit f
   test "attachment fields", context do
     [attachment|_] = eval_template(context.engine,
                                    "attachment_fields",

--- a/test/greenbar/tags/attachment_test.exs
+++ b/test/greenbar/tags/attachment_test.exs
@@ -1,0 +1,73 @@
+defmodule Greenbar.Tags.AttachmentTest do
+  use Greenbar.Test.Support.TestCase
+  alias Greenbar.Engine
+
+  setup_all do
+    {:ok, engine} = Engine.new
+    [engine: engine]
+  end
+
+  defp eval_template(engine, name, template, args) do
+    engine = Engine.compile!(engine, name, template)
+    Engine.eval!(engine, name, args)
+  end
+
+  test "attachment with body", context do
+    result = eval_template(context.engine,
+                           "basic_attachment",
+                           "~attachment~body~end~",
+                           %{})
+
+    assert [%{name: :attachment,
+              fields: [],
+              children: [
+                %{name: :text, text: "body"},
+                %{name: :newline}
+              ]}] == result
+  end
+
+  test "attachment with empty body", context do
+    result = eval_template(context.engine,
+                           "attachment_no_body",
+                           "~attachment~\n~end~",
+                           %{})
+
+    assert [%{name: :attachment,
+              fields: [],
+              children: []}] == result
+  end
+
+  test "attachment attributes", context do
+    result = eval_template(context.engine,
+                           "attachment_attrs",
+                           "~attachment title=title title_url=title_url color=blue image_url=image_url author=author pretext=pretext~body~end~",
+                           %{})
+
+    assert [%{name: :attachment,
+              title: "title",
+              title_url: "title_url",
+              color: "blue",
+              image_url: "image_url",
+              author: "author",
+              pretext: "pretext",
+              fields: [],
+              children: [
+                %{name: :text, text: "body"},
+                %{name: :newline}
+              ]}] == result
+  end
+
+  # Note: The assertion in this case is a little bit f
+  test "attachment fields", context do
+    [attachment|_] = eval_template(context.engine,
+                                   "attachment_fields",
+                                   "~attachment title=title field1=Foo field2=\"Bar Baz\"~body~end~",
+                                   %{})
+
+    fields = Enum.sort(attachment.fields)
+    expected = Enum.sort([%{title: "field1", value: "Foo", short: false},
+                          %{title: "field2", value: "Bar Baz", short: false}])
+
+    assert fields == expected
+  end
+end


### PR DESCRIPTION
    * Added missing `body_tag` grammar productions allowing tags with empty
      bodies to parse and process correctly.
    * Introduced `attr_name` non-terminal which allows quoted strings as tag
      attribute names.