### PR TITLE
use title_link instead of title_url

### DIFF
--- a/lib/greenbar/tags/attachment.ex
+++ b/lib/greenbar/tags/attachment.ex
@@ -8,7 +8,7 @@ defmodule Greenbar.Tags.Attachment do
   The following tag attributes are supported:
 
   * `title` -- Attachment title
-  * `title_url` -- Optional title link URL
+  * `title_link` -- Optional title link URL
   * `color` -- Color to be used when rendering attachment (interpretation may vary by provider)
   * `image_url` -- Link to image asset (if any)
   * `author` -- Author name
@@ -102,8 +102,8 @@ defmodule Greenbar.Tags.Attachment do
   defp gen_attributes({"title", value}, {attachment, fields}) do
     {Map.put(attachment, :title, value), fields}
   end
-  defp gen_attributes({"title_url", value}, {attachment, fields}) do
-    {Map.put(attachment, :title_url, value), fields}
+  defp gen_attributes({"title_link", value}, {attachment, fields}) do
+    {Map.put(attachment, :title_link, value), fields}
   end
   defp gen_attributes({"pretext", value}, {attachment, fields}) do
     {Map.put(attachment, :pretext, value), fields}


### PR DESCRIPTION
Slack uses the `title_link` field to define a link for a title. We were using `title_url`, so `title_link` was just showing as a random field in attachments. This changes the `title_url` attribute to `title_link`.