### PR TITLE
Markdown processing improvements

### DIFF
--- a/lib/greenbar/compiler.ex
+++ b/lib/greenbar/compiler.ex
@@ -7,10 +7,10 @@ defmodule Greenbar.Compiler do
     quoted_body = Enum.map(body, &emit/1)
     quote do
       alias Greenbar.Runtime
+      alias Greenbar.Runtime.Buffer
       alias Greenbar.Tag
       fn(scope, buffer) ->
         unquote_splicing(quoted_body)
-        buffer = Enum.reverse(buffer)
         Greenbar.DirectivesGenerator.generate(buffer)
       end
     end

--- a/lib/greenbar/compiler.ex
+++ b/lib/greenbar/compiler.ex
@@ -1,0 +1,67 @@
+defmodule Greenbar.Compiler do
+
+  alias Greenbar.Compiler.TagAttributes
+  alias Greenbar.Render
+
+  def compile(body) do
+    quoted_body = Enum.map(body, &emit/1)
+    quote do
+      alias Greenbar.Runtime
+      alias Greenbar.Tag
+      fn(scope, buffer) ->
+        unquote_splicing(quoted_body)
+        buffer = Enum.reverse(buffer)
+        Greenbar.DirectivesGenerator.generate(buffer)
+      end
+    end
+  end
+
+  def emit({:text, text}) do
+    quote bind_quoted: [text: text] do
+      buffer = Render.text(buffer, text)
+    end
+  end
+  def emit(:eol) do
+    quote do
+      buffer = Render.eol(buffer)
+    end
+  end
+  def emit({:var, name, nil}) do
+    quote bind_quoted: [name: name] do
+      buffer = Render.var(buffer, name, scope)
+    end
+  end
+  def emit({:var, name, ops}) do
+    quote bind_quoted: [name: name, ops: ops] do
+      buffer = Render.var(buffer, name, ops, scope)
+    end
+  end
+  def emit({:tag, name, nil, nil}) do
+    quote bind_quoted: [name: name] do
+      {scope, buffer} = Render.tag(buffer, name, scope)
+    end
+  end
+  def emit({:tag, name, attrs, nil}) do
+    attr_exprs = TagAttributes.compile(attrs)
+    quote bind_quoted: [name: name, attr_exprs: attr_exprs] do
+      {scope, buffer} = Render.tag(buffer, name, attr_exprs, scope)
+    end
+  end
+  def emit({:tag, name, attrs, body}) do
+    attr_exprs = TagAttributes.compile(attrs)
+    body_fn = generate_tag_body(body)
+    quote do
+      {scope, buffer} = Render.tag(buffer, unquote(name), unquote(attr_exprs), unquote(body_fn), scope)
+    end
+  end
+
+  defp generate_tag_body(tag_body) do
+    quoted_body = Enum.map(tag_body, &emit/1)
+    quote do
+      fn(scope, buffer) ->
+        unquote_splicing(quoted_body)
+      end
+    end
+  end
+
+end

--- a/lib/greenbar/compiler/tag_attrs.ex
+++ b/lib/greenbar/compiler/tag_attrs.ex
@@ -1,78 +1,27 @@
-defmodule Greenbar.Generator do
+defmodule Greenbar.Compiler.TagAttributes do
 
-  def generate_template(body) do
-    quoted_body = Enum.map(body, &emit/1)
+  def compile(attrs) do
+    exprs = build_attr_exprs(attrs, nil)
     quote do
-      fn(scope, buffer) ->
-        unquote_splicing(quoted_body)
-        buffer = Enum.reverse(buffer)
-        Greenbar.DirectivesGenerator.generate(buffer)
-      end
+      fn(scope) -> unquote(exprs) end
     end
   end
 
-  def emit({:text, text}) do
-    quote bind_quoted: [text: text] do
-      buffer = (fn(buffer) -> Greenbar.Runtime.add_to_buffer(%{name: :text, text: text}, buffer) end).(buffer)
-    end
+  defp attrs_pipe_start(nil) do
+    quote do %{} end
   end
-  def emit(:eol) do
-    quote do
-      buffer = (fn(buffer) -> Greenbar.Runtime.add_to_buffer(%{name: :newline}, buffer) end).(buffer)
-    end
-  end
-  def emit({:var, name, nil}) do
-    quote bind_quoted: [name: name] do
-      buffer = (fn(scope, buffer) ->
-        Greenbar.Runtime.add_to_buffer(%{name: :text, text: Greenbar.Runtime.var_to_text(scope, name)}, buffer) end).(scope, buffer)
-    end
-  end
-  def emit({:var, name, ops}) do
-    quote bind_quoted: [name: name, ops: ops] do
-      buffer = (fn(scope, buffer) ->
-        Greenbar.Runtime.add_to_buffer(%{name: :text, text: Greenbar.Runtime.var_to_text(scope, name, ops)}, buffer) end).(scope, buffer)
-    end
-  end
-  def emit({:tag, name, nil, nil}) do
-    tag_id = next_tag_id()
-    quote bind_quoted: [name: name, tag_id: tag_id] do
-      {scope, buffer} = (fn(scope, buffer) ->
-        tag_mod = Greenbar.Runtime.get_tag!(scope, name)
-        Greenbar.Tag.render!(tag_id, tag_mod, nil, scope, buffer) end).(scope, buffer)
-    end
-  end
-  def emit({:tag, name, attrs, nil}) do
-    tag_id = next_tag_id()
-    tag_attr_exprs = build_attr_exprs(attrs, nil)
-    quote bind_quoted: [name: name, tag_id: tag_id, tag_attr_exprs: tag_attr_exprs] do
-      {scope, buffer} = (fn(scope, buffer) ->
-        attrs = tag_attr_exprs
-        tag_mod = Greenbar.Runtime.get_tag!(scope, name)
-        Greenbar.Tag.render!(tag_id, tag_mod, attrs, scope, buffer) end).(scope, buffer)
-    end
-  end
-  def emit({:tag, name, attrs, body}) do
-    tag_id = next_tag_id()
-    tag_attr_exprs = build_attr_exprs(attrs, nil)
-    quoted_body_fn = generate_tag_body(body)
-    quote do
-      {scope, buffer} = (fn(scope, buffer) ->
-        body_fn = unquote(quoted_body_fn)
-        attrs = unquote(tag_attr_exprs)
-        tag_mod = Greenbar.Runtime.get_tag!(scope, unquote(name))
-        Greenbar.Tag.render!(unquote(tag_id), tag_mod, attrs, body_fn, scope, buffer) end).(scope, buffer)
-    end
-  end
+  defp attrs_pipe_start(expr), do: expr
+
 
   defp build_attr_exprs([], attr_expr) do
     attr_expr
   end
   defp build_attr_exprs([{:assign_tag_attr, attr_name, {type, _, value}}|t], expr) when type in [:integer, :float, :string] do
-    expr = Macro.pipe(tag_attr_pipe_expr(expr), quote do Map.put(unquote(attr_name), unquote(value)) end, 0)
+    expr = Macro.pipe(attrs_pipe_start(expr), quote do Map.put(unquote(attr_name), unquote(value)) end, 0)
     build_attr_exprs(t, expr)
   end
   defp build_attr_exprs([{:assign_tag_attr, attr_name, {:var, name, ops}}|t], expr) do
-    expr = Macro.pipe(tag_attr_pipe_expr(expr), quote do
+    expr = Macro.pipe(attrs_pipe_start(expr), quote do
                        Map.put(unquote(attr_name),
                          Greenbar.Runtime.var_to_value(scope, unquote(name), unquote(ops)))
     end, 0)
@@ -82,7 +31,7 @@ defmodule Greenbar.Generator do
   # greater than
   defp build_attr_exprs([{:assign_tag_attr, attr_name, {:gt, {:var, name, ops},
                                                         {type, _, value}}}|t], expr) when type in [:integer, :float] do
-    expr = Macro.pipe(tag_attr_pipe_expr(expr), quote do
+    expr = Macro.pipe(attrs_pipe_start(expr), quote do
                        Map.put(unquote(attr_name),
                        (Kernel.>(Greenbar.Runtime.var_to_value(scope, unquote(name), unquote(ops)), unquote(value))))
     end, 0)
@@ -92,7 +41,7 @@ defmodule Greenbar.Generator do
   # greater than equal
   defp build_attr_exprs([{:assign_tag_attr, attr_name, {:gte, {:var, name, ops},
                                                         {type, _, value}}}|t], expr) when type in [:integer, :float] do
-    expr = Macro.pipe(tag_attr_pipe_expr(expr), quote do
+    expr = Macro.pipe(attrs_pipe_start(expr), quote do
                        Map.put(unquote(attr_name), (Kernel.>=(Greenbar.Runtime.var_to_value(scope, unquote(name), unquote(ops)),
                              unquote(value))))
     end, 0)
@@ -102,7 +51,7 @@ defmodule Greenbar.Generator do
   # less than
   defp build_attr_exprs([{:assign_tag_attr, attr_name, {:lt, {:var, name, ops},
                                                         {type, _, value}}}|t], expr) when type in [:integer, :float] do
-    expr = Macro.pipe(tag_attr_pipe_expr(expr), quote do
+    expr = Macro.pipe(attrs_pipe_start(expr), quote do
                        Map.put(unquote(attr_name),
                        (Kernel.<(Greenbar.Runtime.var_to_value(scope, unquote(name), unquote(ops)), unquote(value))))
     end, 0)
@@ -112,7 +61,7 @@ defmodule Greenbar.Generator do
   # less than equal
   defp build_attr_exprs([{:assign_tag_attr, attr_name, {:lte, {:var, name, ops},
                                                         {type, _, value}}}|t], expr) when type in [:integer, :float] do
-    expr = Macro.pipe(tag_attr_pipe_expr(expr), quote do
+    expr = Macro.pipe(attrs_pipe_start(expr), quote do
                        Map.put(unquote(attr_name),
                        (Kernel.<(Greenbar.Runtime.var_to_value(scope, unquote(name), unquote(ops)), unquote(value)) or
                          Kernel.==(Greenbar.Runtime.var_to_value(scope, unquote(name), unquote(ops)), unquote(value))))
@@ -123,7 +72,7 @@ defmodule Greenbar.Generator do
   # equal
   defp build_attr_exprs([{:assign_tag_attr, attr_name, {:equal, {:var, name, ops},
                                                         {type, _, value}}}|t], expr) when type in [:integer, :float, :string] do
-    expr = Macro.pipe(tag_attr_pipe_expr(expr), quote do
+    expr = Macro.pipe(attrs_pipe_start(expr), quote do
                        Map.put(unquote(attr_name),
                        (Kernel.==(Greenbar.Runtime.var_to_value(scope, unquote(name), unquote(ops)), unquote(value))))
     end, 0)
@@ -133,7 +82,7 @@ defmodule Greenbar.Generator do
   # not equal
   defp build_attr_exprs([{:assign_tag_attr, attr_name, {:not_equal, {:var, name, ops},
                                                         {type, _, value}}}|t], expr) when type in [:integer, :float, :string] do
-    expr = Macro.pipe(tag_attr_pipe_expr(expr), quote do
+    expr = Macro.pipe(attrs_pipe_start(expr), quote do
                        Map.put(unquote(attr_name),
                        (Kernel.!==(Greenbar.Runtime.var_to_value(scope, unquote(name), unquote(ops)), unquote(value))))
     end, 0)
@@ -142,7 +91,7 @@ defmodule Greenbar.Generator do
 
   # empty
   defp build_attr_exprs([{:assign_tag_attr, attr_name, {:empty, {:var, name, ops}}}|t], expr) do
-    expr = Macro.pipe(tag_attr_pipe_expr(expr), quote do
+    expr = Macro.pipe(attrs_pipe_start(expr), quote do
                        Map.put(unquote(attr_name),
                          Greenbar.Runtime.empty?(Greenbar.Runtime.var_to_value(scope, unquote(name), unquote(ops))))
     end, 0)
@@ -151,7 +100,7 @@ defmodule Greenbar.Generator do
 
   # not empty
   defp build_attr_exprs([{:assign_tag_attr, attr_name, {:not_empty, {:var, name, ops}}}|t], expr) do
-    expr = Macro.pipe(tag_attr_pipe_expr(expr), quote do
+    expr = Macro.pipe(attrs_pipe_start(expr), quote do
                        Map.put(unquote(attr_name),
                          Greenbar.Runtime.not_empty?(Greenbar.Runtime.var_to_value(scope, unquote(name), unquote(ops))))
     end, 0)
@@ -161,7 +110,7 @@ defmodule Greenbar.Generator do
 
   # bound
   defp build_attr_exprs([{:assign_tag_attr, attr_name, {:bound, {:var, name, ops}}}|t], expr) do
-    expr = Macro.pipe(tag_attr_pipe_expr(expr), quote do
+    expr = Macro.pipe(attrs_pipe_start(expr), quote do
                        Map.put(unquote(attr_name),
                          Greenbar.Runtime.bound?(Greenbar.Runtime.var_to_value(scope, unquote(name), unquote(ops))))
     end, 0)
@@ -170,29 +119,11 @@ defmodule Greenbar.Generator do
 
   # not bound
   defp build_attr_exprs([{:assign_tag_attr, attr_name, {:not_bound, {:var, name, ops}}}|t], expr) do
-    expr = Macro.pipe(tag_attr_pipe_expr(expr), quote do
+    expr = Macro.pipe(attrs_pipe_start(expr), quote do
                        Map.put(unquote(attr_name),
                          Greenbar.Runtime.not_bound?(Greenbar.Runtime.var_to_value(scope, unquote(name), unquote(ops))))
     end, 0)
     build_attr_exprs(t, expr)
-  end
-
-  defp tag_attr_pipe_expr(nil) do
-    quote do %{} end
-  end
-  defp tag_attr_pipe_expr(expr), do: expr
-
-  defp generate_tag_body(tag_body) do
-    quoted_body = Enum.map(tag_body, &emit/1)
-    quote do
-      fn(scope, buffer) ->
-        unquote_splicing(quoted_body)
-      end
-    end
-  end
-
-  defp next_tag_id() do
-    :erlang.abs(:erlang.monotonic_time())
   end
 
 end

--- a/lib/greenbar/directives_generator.ex
+++ b/lib/greenbar/directives_generator.ex
@@ -26,7 +26,6 @@ defmodule Greenbar.DirectivesGenerator do
   end
   defp parse_markdown(value), do: [value]
 
-  defp make_text_node(""), do: %{name: :newline}
   defp make_text_node(text), do: %{name: :text, text: text}
 
   defp drop_trailing_newline([]), do: []

--- a/lib/greenbar/directives_generator.ex
+++ b/lib/greenbar/directives_generator.ex
@@ -2,31 +2,29 @@ defmodule Greenbar.DirectivesGenerator do
 
   def generate(outputs) do
     outputs
-    |> Enum.flat_map(&process_markdown/1)
+    |> process_markdown
     |> drop_trailing_newline
-    |> Enum.reduce([], &combine_text_nodes/2)
-    |> Enum.reverse
+    |> combine_text_nodes
+    |> Enum.flat_map(&split_newline/1)
   end
 
-  defp process_markdown(%{name: :attachment, children: children}=attachment) do
-    updated = Enum.flat_map(children, &process_markdown/1)
+  defp process_markdown(outputs) do
+    Enum.flat_map(outputs, &parse_markdown/1)
+  end
+
+  defp parse_markdown(%{name: :attachment, children: children}=attachment) do
+    updated = generate(children)
     [Map.put(attachment, :children, updated)]
   end
-  defp process_markdown(%{name: :text, text: text}) do
+  defp parse_markdown(%{name: :text, text: text}) do
     {:ok, parsed} = :greenbar_markdown.analyze(text)
-    parsed
-    |> Enum.flat_map(&manually_split_newlines/1)
+    if String.contains?(text, "\n") do
+      parsed
+    else
+      Enum.filter(parsed, &(Map.get(&1, :name) != :newline))
+    end
   end
-  defp process_markdown(value), do: [value]
-
-  defp manually_split_newlines(%{name: :text, text: ""}), do: []
-  defp manually_split_newlines(%{name: :text, text: "\n"}), do: [%{name: :newline}]
-  defp manually_split_newlines(%{name: :text, text: text}) do
-    text
-    |> String.split("\n")
-    |> Enum.map(&make_text_node/1)
-  end
-  defp manually_split_newlines(value), do: [value]
+  defp parse_markdown(value), do: [value]
 
   defp make_text_node(""), do: %{name: :newline}
   defp make_text_node(text), do: %{name: :text, text: text}
@@ -41,11 +39,29 @@ defmodule Greenbar.DirectivesGenerator do
     end
   end
 
+  defp combine_text_nodes(nodes) do
+    Enum.reduce(nodes, [], &combine_text_nodes/2) |> Enum.reverse
+  end
   defp combine_text_nodes(value, []), do: [value]
   defp combine_text_nodes(%{name: :text, text: t2text}, [%{name: :text, text: t1text}|t]) do
     combined = %{name: :text, text: Enum.join([t1text, t2text])}
     [combined|t]
   end
   defp combine_text_nodes(value, accum), do: [value|accum]
+
+  defp split_newline(%{name: :attachment, children: children}=attachment) do
+    [%{attachment | children: Enum.flat_map(children, &split_newline/1)}]
+  end
+  defp split_newline(%{name: :text, text: text}) do
+    case String.split(text, "\n", trim: true) do
+      [^text] ->
+        [%{name: :text, text: text}]
+      [partial] ->
+        [%{name: :newline}, %{name: :text, text: partial}]
+      items ->
+        items |> Enum.map(&make_text_node/1) |> Enum.intersperse(%{name: :newline})
+    end
+  end
+  defp split_newline(item), do: [item]
 
 end

--- a/lib/greenbar/render.ex
+++ b/lib/greenbar/render.ex
@@ -1,24 +1,25 @@
 defmodule Greenbar.Render do
 
   alias Greenbar.Runtime
+  alias Greenbar.Runtime.Buffer
   alias Greenbar.Tag
 
   def text(buffer, text) do
-    Runtime.add_to_buffer(%{name: :text, text: text}, buffer)
+    Buffer.append!(buffer, %{name: :text, text: text})
   end
 
   def eol(buffer) do
-    Runtime.add_to_buffer(%{name: :newline}, buffer)
+    Buffer.append!(buffer, %{name: :newline})
   end
 
   def var(buffer, name, scope) do
     value = Runtime.var_to_text(scope, name)
-    Runtime.add_to_buffer(%{name: :text, text: value}, buffer)
+    Buffer.append!(buffer, %{name: :text, text: value})
   end
 
   def var(buffer, name, ops, scope) do
     value = Runtime.var_to_text(scope, name, ops)
-    Runtime.add_to_buffer(%{name: :text, text: value}, buffer)
+    Buffer.append!(buffer, %{name: :text, text: value})
   end
 
   def tag(buffer, name, scope) do

--- a/lib/greenbar/render.ex
+++ b/lib/greenbar/render.ex
@@ -1,0 +1,46 @@
+defmodule Greenbar.Render do
+
+  alias Greenbar.Runtime
+  alias Greenbar.Tag
+
+  def text(buffer, text) do
+    Runtime.add_to_buffer(%{name: :text, text: text}, buffer)
+  end
+
+  def eol(buffer) do
+    Runtime.add_to_buffer(%{name: :newline}, buffer)
+  end
+
+  def var(buffer, name, scope) do
+    value = Runtime.var_to_text(scope, name)
+    Runtime.add_to_buffer(%{name: :text, text: value}, buffer)
+  end
+
+  def var(buffer, name, ops, scope) do
+    value = Runtime.var_to_text(scope, name, ops)
+    Runtime.add_to_buffer(%{name: :text, text: value}, buffer)
+  end
+
+  def tag(buffer, name, scope) do
+    tag_id = next_tag_id()
+    tag_mod = Runtime.get_tag!(scope, name)
+    Tag.render!(tag_id, tag_mod, nil, scope, buffer)
+  end
+
+  def tag(buffer, name, attrs, scope) do
+    tag_id = next_tag_id()
+    tag_mod = Runtime.get_tag!(scope, name)
+    Tag.render!(tag_id, tag_mod, attrs.(scope), scope, buffer)
+  end
+
+  def tag(buffer, name, attrs, body_fn, scope) do
+    tag_id = next_tag_id()
+    tag_mod = Runtime.get_tag!(scope, name)
+    Tag.render!(tag_id, tag_mod, attrs.(scope), body_fn, scope, buffer)
+  end
+
+  defp next_tag_id() do
+    :erlang.abs(:erlang.monotonic_time())
+  end
+
+end

--- a/lib/greenbar/runtime.ex
+++ b/lib/greenbar/runtime.ex
@@ -1,8 +1,8 @@
 defmodule Greenbar.Runtime do
 
-    @allowed_directive_atoms Enum.sort([:text, :newline, :bold, :italics, :fixed_width, :header, :link,
-                              :attachment])
-    @allowed_directive_strings Enum.sort(Enum.map(@allowed_directive_atoms, &(Atom.to_string(&1))))
+  @allowed_directive_atoms Enum.sort([:text, :newline, :bold, :italics, :fixed_width, :header, :link,
+                                      :attachment])
+  @allowed_directive_strings Enum.sort(Enum.map(@allowed_directive_atoms, &(Atom.to_string(&1))))
 
   alias Piper.Common.Scope.Scoped
   alias Greenbar.EvaluationError

--- a/lib/greenbar/runtime.ex
+++ b/lib/greenbar/runtime.ex
@@ -83,34 +83,10 @@ defmodule Greenbar.Runtime do
     end
   end
 
-  def add_to_buffer(%{name: :text, text: text}, [%{name: :text, text: bt}|buffer]) do
-    [%{name: :text, text: Enum.join([bt, text])}|buffer]
-  end
-  def add_to_buffer(item, buffer), do: [item|buffer]
-
   def stringify_value(nil), do: ""
   def stringify_value(value) when is_list(value) or is_map(value), do: Poison.encode!(value)
   def stringify_value(value) when is_binary(value), do: value
   def stringify_value(value), do: "#{value}"
-
-  def add_tag_output!(nil, buffer, _tag_mod), do: buffer
-  def add_tag_output!(output, buffer, _tag_mod) when is_binary(output) do
-    add_to_buffer(%{name: :text, text: output}, buffer)
-  end
-  def add_tag_output!(%{name: name}=output, buffer, tag_mod) do
-    case allowed_directive?(name) do
-      true ->
-        add_to_buffer(output, buffer)
-      false ->
-        raise Greenbar.EvaluationError, message: "Tag '#{tag_mod.name()}' returned an unknown directive: #{inspect name}"
-    end
-  end
-  def add_tag_output!(outputs, buffer, tag_mod) when is_list(outputs) do
-    Enum.reduce(outputs, buffer, fn(output, buffer) -> add_tag_output!(output, buffer, tag_mod) end)
-  end
-  def add_tag_output!(output, _, tag_mod) do
-    raise Greenbar.EvaluationError, message: "Tag '#{tag_mod.name()}' returned invalid output: #{inspect output, pretty: true}"
-  end
 
   def funcall("length", nil), do: 0
   def funcall("length", value) when is_list(value) or is_map(value) do
@@ -120,9 +96,5 @@ defmodule Greenbar.Runtime do
   def funcall(name, _) do
     raise Greenbar.EvaluationError, message: "Unknown built-in function '#{name}'"
   end
-
-  defp allowed_directive?(name) when name in @allowed_directive_atoms, do: true
-  defp allowed_directive?(name) when name in @allowed_directive_strings, do: true
-  defp allowed_directive?(_), do: false
 
 end

--- a/lib/greenbar/runtime/buffer.ex
+++ b/lib/greenbar/runtime/buffer.ex
@@ -1,0 +1,107 @@
+defmodule Greenbar.Runtime.Buffer do
+
+  alias Greenbar.EvaluationError
+
+  @allowed_directive_atoms Enum.sort([:text, :newline, :bold, :italics, :fixed_width, :header, :link,
+                                      :attachment])
+  @allowed_directive_strings Enum.sort(Enum.map(@allowed_directive_atoms, &(Atom.to_string(&1))))
+
+  defstruct [items: [], last: nil]
+
+  def append!(%__MODULE__{}=buffer, nil), do: buffer
+  def append!(%__MODULE__{}=buffer, text) when is_binary(text) do
+    append!(buffer, %{name: :text, text: text})
+  end
+  def append!(%__MODULE__{last: %{name: :text, text: t1}}=buffer, %{name: :text, text: t2}) do
+    %{buffer | last: %{name: :text, text: Enum.join([t1, t2])}}
+  end
+  def append!(%__MODULE__{last: nil}=buffer, %{name: name}=item) do
+    if allowed_directive?(name) do
+      %{buffer | last: item}
+    else
+      raise EvaluationError, message: "Unknown directive: #{inspect name}"
+    end
+  end
+  def append!(%__MODULE__{items: items, last: last}=buffer, %{name: name}=item) do
+    if allowed_directive?(name) do
+      %{buffer | items: items ++ [last], last: item}
+    else
+      raise EvaluationError, message: "Unknown directive: #{inspect name}"
+    end
+  end
+  def append!(%__MODULE__{}=buffer, items) when is_list(items) do
+    Enum.reduce(items, buffer, &(append!(&2, &1)))
+  end
+  def append!(%__MODULE__{}, unknown_item) do
+    raise EvaluationError, message: "Cannot process unknown template output: #{inspect unknown_item}"
+  end
+
+  def join(%__MODULE__{}=firstbuf, %__MODULE__{}=secondbuf) do
+    case items(firstbuf) ++ items(secondbuf) do
+      [] ->
+        %__MODULE__{}
+      [item] ->
+        %__MODULE__{last: item}
+      items ->
+        case consolidate(items) do
+          [item] ->
+            %__MODULE__{last: item}
+          items ->
+            last = List.last(items)
+            items = List.delete_at(items, -1)
+            %__MODULE__{last: last, items: items}
+        end
+    end
+  end
+
+  def items(%__MODULE__{items: items, last: nil}), do: items
+  def items(%__MODULE__{items: items, last: last}), do: items ++ [last]
+
+  def empty?(%__MODULE__{items: [], last: nil}), do: true
+  def empty?(%__MODULE__{}), do: false
+
+  defp allowed_directive?(name) when name in @allowed_directive_atoms, do: true
+  defp allowed_directive?(name) when name in @allowed_directive_strings, do: true
+  defp allowed_directive?(_), do: false
+
+  defp consolidate(items) do
+    Enum.reduce(items, [], &consolidate/2)
+    |> Enum.reverse
+  end
+  defp consolidate(item, []), do: [item]
+  defp consolidate(%{name: text, text: t2}, [%{name: :text, text: t1}|t]) do
+    t3 = %{name: text, text: t1 <> t2}
+    [t3|t]
+  end
+  defp consolidate(item, acc), do: [item|acc]
+
+end
+
+defimpl Enumerable, for: Greenbar.Runtime.Buffer do
+
+  alias Greenbar.Runtime.Buffer
+
+  def count(%Buffer{}=buf) do
+    Enum.count(Buffer.items(buf))
+  end
+
+  def member?(%Buffer{}=buf, item) do
+    Enum.member?(Buffer.items(buf), item)
+  end
+
+  def reduce(_, {:halt, acc}, _fun), do: {:halted, acc}
+  def reduce(%Buffer{}=buf, {:suspend, acc}, fun), do: {:suspended, acc, &reduce(buf, &1, fun)}
+  def reduce(%Buffer{}=buf, {:cont, acc}, fun) do
+    if Buffer.empty?(buf) do
+      {:done, acc}
+    else
+      case buf do
+        %Buffer{items: [], last: last} ->
+          reduce(%{buf | last: nil}, fun.(last, acc), fun)
+        %Buffer{items: [h|t]} ->
+          reduce(%{buf| items: t}, fun.(h, acc), fun)
+      end
+    end
+  end
+
+end

--- a/lib/greenbar/tags/attachment.ex
+++ b/lib/greenbar/tags/attachment.ex
@@ -1,5 +1,7 @@
 defmodule Greenbar.Tags.Attachment do
 
+  alias Greenbar.Runtime.Buffer
+
   @moduledoc """
   Wraps body in an attachment directive
 
@@ -83,8 +85,9 @@ defmodule Greenbar.Tags.Attachment do
   def post_body(_id, attrs, scope, _body_scope, response) do
     attachment = make_attachment(attrs)
     # Reverse the body to get it in the correct order for the attachment
-    children = Enum.reverse(response)
-    {:ok, scope, Map.put(attachment, :children, children)}
+    buffer = %Buffer{}
+    attachment = Map.put(attachment, :children, Buffer.items(response))
+    {:ok, scope, Buffer.append!(buffer, attachment)}
   end
 
   defp make_attachment(nil) do

--- a/lib/greenbar/template.ex
+++ b/lib/greenbar/template.ex
@@ -3,6 +3,7 @@ defmodule Greenbar.Template do
   alias Piper.Common.Scope
   alias Piper.Common.Scope.Scoped
   alias Greenbar.Compiler
+  alias Greenbar.Runtime.Buffer
 
   defstruct [:name, :template_fn, :source, :hash, :timestamp, :debug_source]
 
@@ -20,7 +21,7 @@ defmodule Greenbar.Template do
   def eval!(%__MODULE__{}=template, engine, scope) do
     eval_scope = Scope.from_map(scope)
     {:ok, eval_scope} = Scoped.set(eval_scope, "__ENGINE__", engine)
-    template.template_fn.(eval_scope, [])
+    template.template_fn.(eval_scope, %Buffer{})
   end
 
 end
@@ -28,7 +29,7 @@ end
 defimpl String.Chars, for: Greenbar.Template do
 
   def to_string(template) do
-    "Greenbar.Template<name: #{template.name},timestamp: #{template.timestamp}, hash: #{template.hash}>"
+    "#Greenbar.Template<name: #{template.name},timestamp: #{template.timestamp}, hash: #{template.hash}>"
   end
 
 end

--- a/lib/greenbar/template.ex
+++ b/lib/greenbar/template.ex
@@ -2,12 +2,12 @@ defmodule Greenbar.Template do
 
   alias Piper.Common.Scope
   alias Piper.Common.Scope.Scoped
-  alias Greenbar.Generator
+  alias Greenbar.Compiler
 
   defstruct [:name, :template_fn, :source, :hash, :timestamp, :debug_source]
 
   def compile!(name, parsed, opts \\ []) do
-    quoted = Generator.generate_template(parsed)
+    quoted = Compiler.compile(parsed)
     {template_fn, _} = Code.eval_quoted(quoted)
     debug_source = if Keyword.get(opts, :debug, false) == true do
       Macro.to_string(quoted)

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
-  "greenbar_markdown": {:git, "https://github.com/operable/greenbar_markdown.git", "999c9da12f4b44e9a328ad39681f0dc17976fb5e", []},
+  "greenbar_markdown": {:git, "https://github.com/operable/greenbar_markdown.git", "fdf9dd9334f64b83526f7f13bbb4c50576cf0fe6", []},
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
   "piper": {:git, "https://github.com/operable/piper.git", "e464ebd5e21532601c782d6c3a7d56eb3f69d4d0", []},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},

--- a/test/eval_test.exs
+++ b/test/eval_test.exs
@@ -236,4 +236,15 @@ defmodule Greenbar.EvalTest do
                          color: "red", fields: [], name: :attachment}]
   end
 
+  test "bold and bullets are parsed correctly", context do
+    result = eval_template(context.engine, "bold_and_bullets", Templates.bold_and_bullets, %{})
+    assert result === [%{name: :bold, text: "test"},
+                       %{children: [%{children: [%{name: :text, text: "one"}, %{name: :newline}],
+                                      name: :list_item},
+                                    %{children: [%{name: :text, text: "two"}, %{name: :newline}],
+                                      name: :list_item},
+                                    %{children: [%{name: :text, text: "three"}, %{name: :newline}],
+                                      name: :list_item}],
+                         name: :unordered_list}]
+  end
 end

--- a/test/eval_test.exs
+++ b/test/eval_test.exs
@@ -238,7 +238,7 @@ defmodule Greenbar.EvalTest do
 
   test "bold and bullets are parsed correctly", context do
     result = eval_template(context.engine, "bold_and_bullets", Templates.bold_and_bullets, %{})
-    assert result === [%{name: :bold, text: "test"},
+    assert result === [%{name: :bold, text: "test"}, %{name: :newline},
                        %{children: [%{children: [%{name: :text, text: "one"}, %{name: :newline}],
                                       name: :list_item},
                                     %{children: [%{name: :text, text: "two"}, %{name: :newline}],

--- a/test/eval_test.exs
+++ b/test/eval_test.exs
@@ -232,7 +232,7 @@ defmodule Greenbar.EvalTest do
   test "attachment tag's body is in the correct order", context do
     result = eval_template(context.engine, "foo2", "~attachment color=\"red\"~\nThis is a test\n```\nThis is another test\n```\n~end~", %{})
     assert result === [%{children: [%{name: :text, text: "This is a test"}, %{name: :newline},
-                                    %{name: :fixed_width, text: "\nThis is another test\n"}, %{name: :newline}],
+                                    %{name: :fixed_width, text: "\nThis is another test\n"}],
                          color: "red", fields: [], name: :attachment}]
   end
 

--- a/test/greenbar/tags/attachment_test.exs
+++ b/test/greenbar/tags/attachment_test.exs
@@ -21,8 +21,7 @@ defmodule Greenbar.Tags.AttachmentTest do
     assert [%{name: :attachment,
               fields: [],
               children: [
-                %{name: :text, text: "body"},
-                %{name: :newline}
+                %{name: :text, text: "body"}
               ]}] == result
   end
 
@@ -116,8 +115,7 @@ _~$thing~_
               pretext: "pretext",
               fields: [],
               children: [
-                %{name: :text, text: "body"},
-                %{name: :newline}
+                %{name: :text, text: "body"}
               ]}] == result
   end
 

--- a/test/support/prefix_tag.ex
+++ b/test/support/prefix_tag.ex
@@ -7,7 +7,10 @@ defmodule Greenbar.Test.Support.PrefixTag do
   end
 
   def post_body(_id, _attrs, scope, _body_scope, body) do
-    {:ok, scope, body ++ [%{name: :text, text: "This is the prefix tag."}]}
+    body = %Buffer{}
+           |> Buffer.append!("This is the prefix tag.")
+           |> Buffer.join(body)
+    {:ok, scope, body}
   end
 
 end

--- a/test/support/templates.ex
+++ b/test/support/templates.ex
@@ -206,6 +206,7 @@ No puppies :(
   def bold_and_bullets do
     """
     __test__
+
     * one
     * two
     * three

--- a/test/support/templates.ex
+++ b/test/support/templates.ex
@@ -203,4 +203,12 @@ No puppies :(
 """
   end
 
+  def bold_and_bullets do
+    """
+    __test__
+    * one
+    * two
+    * three
+    """
+  end
 end


### PR DESCRIPTION
This PR improves (I hope!) the readability of Greenbar's internals, fixes a couple of very subtle and hard to reproduce output ordering bugs, and improves Greenbar's Markdown handling.

These changes have been successfully tested in the `kevsmith/markdown-bug` branch of `operable/cog` requiring very minor tweaks to the `which.greenbar` template.