### PR TITLE
Add support for Markdown paragraph & improve newline behavior

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Greenbar.Mixfile do
     [
       # Direct dependencies
       {:piper, github: "operable/piper"},
-      {:greenbar_markdown, github: "operable/greenbar_markdown"},
+      {:greenbar_markdown, github: "operable/greenbar_markdown", branch: "kevsmith/paragraph-children"},
 
       # Test and Development
       {:mix_test_watch, "~> 0.2", only: [:dev, :test]},

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Greenbar.Mixfile do
     [
       # Direct dependencies
       {:piper, github: "operable/piper"},
-      {:greenbar_markdown, github: "operable/greenbar_markdown", branch: "kevsmith/paragraph-children"},
+      {:greenbar_markdown, github: "operable/greenbar_markdown"},
 
       # Test and Development
       {:mix_test_watch, "~> 0.2", only: [:dev, :test]},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
-  "greenbar_markdown": {:git, "https://github.com/operable/greenbar_markdown.git", "8e7abbb53d4aff910e947138a9838ddea9d8be9e", [branch: "kevsmith/paragraph-children"]},
+  "greenbar_markdown": {:git, "https://github.com/operable/greenbar_markdown.git", "35333758f4d77507f4f9b5c7a23a7a93fb45ba92", [branch: "kevsmith/paragraph-children"]},
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
   "piper": {:git, "https://github.com/operable/piper.git", "1d52b32f41226398fdb37baca7398bbf0b93c1a3", []},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
-  "greenbar_markdown": {:git, "https://github.com/operable/greenbar_markdown.git", "b98b085f076ac17fc4069b0f68400c90c6e9baf4", [branch: "kevsmith/paragraph-children"]},
+  "greenbar_markdown": {:git, "https://github.com/operable/greenbar_markdown.git", "0bc4bbc33b6afcd8b9189ccf75eee6c8bdfaf8c9", [branch: "kevsmith/paragraph-children"]},
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
   "piper": {:git, "https://github.com/operable/piper.git", "1d52b32f41226398fdb37baca7398bbf0b93c1a3", []},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
-  "greenbar_markdown": {:git, "https://github.com/operable/greenbar_markdown.git", "8efb355e8c893bb3c27f9de143a268b1282365c5", []},
+  "greenbar_markdown": {:git, "https://github.com/operable/greenbar_markdown.git", "58080c78ff82d4b08bc60bcf6ad68711a6b2df1c", [branch: "kevsmith/paragraph-children"]},
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
   "piper": {:git, "https://github.com/operable/piper.git", "1d52b32f41226398fdb37baca7398bbf0b93c1a3", []},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
-  "greenbar_markdown": {:git, "https://github.com/operable/greenbar_markdown.git", "35333758f4d77507f4f9b5c7a23a7a93fb45ba92", [branch: "kevsmith/paragraph-children"]},
+  "greenbar_markdown": {:git, "https://github.com/operable/greenbar_markdown.git", "4aa50d8d052e5d54986ba4b87bda72afff1b16e9", [branch: "kevsmith/paragraph-children"]},
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
   "piper": {:git, "https://github.com/operable/piper.git", "1d52b32f41226398fdb37baca7398bbf0b93c1a3", []},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
-  "greenbar_markdown": {:git, "https://github.com/operable/greenbar_markdown.git", "0e37d510d8c012f23dc7ae20b45a1e9b87151508", [branch: "kevsmith/paragraph-children"]},
+  "greenbar_markdown": {:git, "https://github.com/operable/greenbar_markdown.git", "ad6d027c92ef095a0461c08847d3eb999659c3a2", []},
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
   "piper": {:git, "https://github.com/operable/piper.git", "1d52b32f41226398fdb37baca7398bbf0b93c1a3", []},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
-  "greenbar_markdown": {:git, "https://github.com/operable/greenbar_markdown.git", "0bc4bbc33b6afcd8b9189ccf75eee6c8bdfaf8c9", [branch: "kevsmith/paragraph-children"]},
+  "greenbar_markdown": {:git, "https://github.com/operable/greenbar_markdown.git", "8e7abbb53d4aff910e947138a9838ddea9d8be9e", [branch: "kevsmith/paragraph-children"]},
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
   "piper": {:git, "https://github.com/operable/piper.git", "1d52b32f41226398fdb37baca7398bbf0b93c1a3", []},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
-  "greenbar_markdown": {:git, "https://github.com/operable/greenbar_markdown.git", "58080c78ff82d4b08bc60bcf6ad68711a6b2df1c", [branch: "kevsmith/paragraph-children"]},
+  "greenbar_markdown": {:git, "https://github.com/operable/greenbar_markdown.git", "b98b085f076ac17fc4069b0f68400c90c6e9baf4", [branch: "kevsmith/paragraph-children"]},
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
   "piper": {:git, "https://github.com/operable/piper.git", "1d52b32f41226398fdb37baca7398bbf0b93c1a3", []},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
-  "greenbar_markdown": {:git, "https://github.com/operable/greenbar_markdown.git", "4aa50d8d052e5d54986ba4b87bda72afff1b16e9", [branch: "kevsmith/paragraph-children"]},
+  "greenbar_markdown": {:git, "https://github.com/operable/greenbar_markdown.git", "0e37d510d8c012f23dc7ae20b45a1e9b87151508", [branch: "kevsmith/paragraph-children"]},
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
   "piper": {:git, "https://github.com/operable/piper.git", "1d52b32f41226398fdb37baca7398bbf0b93c1a3", []},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},

--- a/src/gb_parser.yrl
+++ b/src/gb_parser.yrl
@@ -218,7 +218,7 @@ ensure_list(Value) when is_list(Value) -> Value;
 ensure_list(Value) -> [Value].
 
 maybe_drop_leading_eol({body_tag, _, <<"if">>}, Rest) -> Rest;
-maybe_drop_leading_eol(_, Rest) -> drop_leading_eol(Rest).
+maybe_drop_leading_eol(_Tag, Rest) -> drop_leading_eol(Rest).
 
 drop_leading_eol({text, <<"\n">>}) -> [];
 drop_leading_eol([{text, <<"\n">>}|T]) -> T;

--- a/test/eval_test.exs
+++ b/test/eval_test.exs
@@ -275,4 +275,32 @@ defmodule Greenbar.EvalTest do
                                       name: :list_item}],
                          name: :unordered_list}]
   end
+
+  test "another table with each tag", context do
+    result = eval_template(context.engine, "table_with_each", "**List of things**\n\n|Name|Status|Description|\n" <>
+      "|---|---|---|\n" <>
+      "~each var=$results as=thing~\n| ~$thing.name~ | ~$thing.status~ | ~$thing.description~ |\n" <>
+      "~end~\n", %{"results" => [%{"name" => "abc", "status" => "RUNNING", "description" => "Thing abc"},
+                                 %{"name" => "def", "status" => "CREATING", "description" => "Thing def"},
+                                 %{"name" => "ghi", "status" => "DESTROYED", "description" => "Thing ghi"}]})
+    assert result == [%{children: [%{name: :bold, text: "List of things"}], name: :paragraph},
+                      %{children: [
+                           %{children: [%{children: [%{name: :text, text: "Name"}], name: :table_cell},
+                                        %{children: [%{name: :text, text: "Status"}], name: :table_cell},
+                                        %{children: [%{name: :text, text: "Description"}], name: :table_cell}],
+                             name: :table_header},
+                           %{children: [%{children: [%{name: :text, text: "abc"}], name: :table_cell},
+                                        %{children: [%{name: :text, text: "RUNNING"}], name: :table_cell},
+                                        %{children: [%{name: :text, text: "Thing abc"}], name: :table_cell}],
+                             name: :table_row},
+                           %{children: [%{children: [%{name: :text, text: "def"}], name: :table_cell},
+                                        %{children: [%{name: :text, text: "CREATING"}], name: :table_cell},
+                                        %{children: [%{name: :text, text: "Thing def"}], name: :table_cell}],
+                             name: :table_row},
+                           %{children: [%{children: [%{name: :text, text: "ghi"}], name: :table_cell},
+                                        %{children: [%{name: :text, text: "DESTROYED"}], name: :table_cell},
+                                        %{children: [%{name: :text, text: "Thing ghi"}], name: :table_cell}],
+                             name: :table_row}],
+                        name: :table}]
+  end
 end

--- a/test/eval_test.exs
+++ b/test/eval_test.exs
@@ -51,9 +51,9 @@ defmodule Greenbar.EvalTest do
     names = extract_names(result)
     assert names == [{:paragraph, [:text]},
                      :newline,
-                     {:paragraph, [:text, :text, :text, :text]},
-                     {:paragraph, [:text, :text, :text, :text]},
-                     {:paragraph, [:text, :text, :text, :text]}]
+                     {:paragraph, [:text, :newline, :text, :newline, :text]},
+                     {:paragraph, [:text, :newline, :text, :newline, :text]},
+                     {:paragraph, [:text, :newline, :text, :newline, :text]}]
   end
 
   test "if tag", context do
@@ -71,7 +71,7 @@ defmodule Greenbar.EvalTest do
   test "not_empty? check works", context do
     result = eval_template(context.engine, "not_empty_check", Templates.not_empty_check, %{"user_creators" => ["bob", "sue", "frank"]})
     names = extract_names(result)
-    assert names == [:newline, {:paragraph, [:text]}, :newline, {:paragraph, [:text, :text, :text]}]
+    assert names == [:newline, {:paragraph, [:text]}, :newline, {:paragraph, [:text, :newline, :text, :newline, :text]}]
     result = eval_template(context.engine, "not_empty_check", Templates.not_empty_check, %{})
     assert length(result) == 0
   end
@@ -83,12 +83,17 @@ defmodule Greenbar.EvalTest do
                                                                                              %{"name" => "bar", "state" => "terminated",
                                                                                                "id" => "456"}]})
     assert result === [%{children: [%{children: [%{name: :text, text: "ID: 123"},
-                                                %{name: :text, text: "\nName: foo"},
-                                                %{name: :text, text: "\nState: running"}], name: :paragraph}],
-                        color: "green", fields: [], name: :attachment},
+                                                 %{name: :newline},
+                                                 %{name: :text, text: "Name: foo"},
+                                                 %{name: :newline},
+                                                 %{name: :text, text: "State: running"}],
+                                      name: :paragraph}],
+                         color: "green", fields: [], name: :attachment},
                        %{children: [%{children: [%{name: :text, text: "ID: 456"},
-                                                 %{name: :text, text: "\nName: bar"},
-                                                 %{name: :text, text: "\nState: terminated"}], name: :paragraph}],
+                                                 %{name: :newline},
+                                                 %{name: :text, text: "Name: bar"},
+                                                 %{name: :newline},
+                                                 %{name: :text, text: "State: terminated"}], name: :paragraph}],
                          color: "red", fields: [], name: :attachment}]
   end
 
@@ -148,14 +153,20 @@ defmodule Greenbar.EvalTest do
                                                                                            "relay_groups" => [%{"name" => "preprod"},
                                                                                                               %{"name" => "prod"}]}]})
     assert result === [%{children: [%{name: :text, text: "ID: aaaa-bbbb-cccc-dddd-eeee-ffff"},
-                                    %{name: :text, text: "\nName: my"}, %{name: :text, text: "_bundle"}],
+                                    %{name: :newline}, %{name: :text, text: "Name: my_bundle"}],
                          name: :paragraph},
                        %{children: [%{name: :text, text: "Versions: 0.0.1"},
-                                    %{name: :text, text: "\n0.0.2"}, %{name: :text, text: "\n0.0.3"}],
+                                    %{name: :newline},
+                                    %{name: :text, text: "0.0.2"},
+                                    %{name: :newline},
+                                    %{name: :text, text: "0.0.3"}],
                          name: :paragraph},
                        %{children: [%{name: :text, text: "Enabled Version: 0.0.3"},
-                                    %{name: :text, text: "\nRelay Groups: preprod"},
-                                    %{name: :text, text: "\nprod"}], name: :paragraph}]
+                                    %{name: :newline},
+                                    %{name: :text, text: "Relay Groups: preprod"},
+                                    %{name: :newline},
+                                    %{name: :text, text: "prod"}],
+                         name: :paragraph}]
   end
 
   test "length check works", context do
@@ -169,7 +180,7 @@ defmodule Greenbar.EvalTest do
     assert result === [%{name: :paragraph, children: [%{name: :text, text: "One puppy"}]}]
     result = eval_template(context.engine, "length_test", Templates.length_test, %{"pets" => %{"cats" => [1,2],
                                                                                                "puppies" => [1,2,3]}})
-    assert result === [%{name: :paragraph, children: [%{name: :text, text: "Lots of puppies"}, %{name: :text, text: "!"}]}]
+    assert result === [%{name: :paragraph, children: [%{name: :text, text: "Lots of puppies!"}]}]
   end
 
   test "bound check works", context do
@@ -240,8 +251,10 @@ defmodule Greenbar.EvalTest do
   test "wrapping body works", context do
     result = eval_template(context.engine, "foo1", "~prefix~\nThis is a test\nThis is another test\n~end~", %{})
     assert result === [%{name: :paragraph, children: [%{name: :text, text: "This is the prefix tag."},
-                                                      %{name: :text, text: "\nThis is a test"},
-                                                      %{name: :text, text: "\nThis is another test"}]}]
+                                                      %{name: :newline},
+                                                      %{name: :text, text: "This is a test"},
+                                                      %{name: :newline},
+                                                      %{name: :text, text: "This is another test"}]}]
   end
 
   test "attachment tag's body is in the correct order", context do

--- a/test/eval_test.exs
+++ b/test/eval_test.exs
@@ -65,7 +65,7 @@ defmodule Greenbar.EvalTest do
     # Bound? succeeds
     result = eval_template(context.engine, "if_tag", Templates.if_tag, %{"item" => "`Kilroy was here`"})
     names = extract_names(result)
-    assert names == [paragraph: [:text, :fixed_width]]
+    assert names == [paragraph: [:text], paragraph: [:fixed_width]]
   end
 
   test "not_empty? check works", context do

--- a/test/eval_test.exs
+++ b/test/eval_test.exs
@@ -259,7 +259,7 @@ defmodule Greenbar.EvalTest do
 
   test "attachment tag's body is in the correct order", context do
     result = eval_template(context.engine, "foo2", "~attachment color=\"red\"~\nThis is a test\n```\nThis is another test\n```\n~end~", %{})
-    assert result === [%{children: [%{name: :paragraph, children: [%{name: :text, text: "This is a test"},
+    assert result === [%{children: [%{name: :paragraph, children: [%{name: :text, text: "This is a test"}, %{name: :newline},
                                     %{name: :fixed_width, text: "\nThis is another test\n"}]}],
                          color: "red", fields: [], name: :attachment}]
   end

--- a/test/greenbar/tags/attachment_test.exs
+++ b/test/greenbar/tags/attachment_test.exs
@@ -52,14 +52,14 @@ defmodule Greenbar.Tags.AttachmentTest do
       """
 ~attachment~~end~
 ~each var=$things as=thing~
-_~$thing~_
+Displaying _~$thing~_
 ~end~
 """, %{"things" => ["a","b","c","d"]})
     assert [%{children: [], fields: [], name: :attachment},
-            %{name: :paragraph, children: [%{name: :italics, text: "a"},
-                                           %{name: :italics, text: "b"},
-                                           %{name: :italics, text: "c"},
-                                           %{name: :italics, text: "d"}]}] == result
+            %{name: :paragraph, children: [%{name: :text, text: "Displaying "}, %{name: :italics, text: "a"}, %{name: :newline},
+                                           %{name: :text, text: "Displaying "}, %{name: :italics, text: "b"}, %{name: :newline},
+                                           %{name: :text, text: "Displaying "}, %{name: :italics, text: "c"}, %{name: :newline},
+                                           %{name: :text, text: "Displaying "}, %{name: :italics, text: "d"}]}] == result
   end
 
   test "attachment with empty body and attrs with other template content", context do

--- a/test/greenbar/tags/attachment_test.exs
+++ b/test/greenbar/tags/attachment_test.exs
@@ -21,7 +21,7 @@ defmodule Greenbar.Tags.AttachmentTest do
     assert [%{name: :attachment,
               fields: [],
               children: [
-                %{name: :text, text: "body"}
+                %{name: :paragraph, children: [%{name: :text, text: "body"}]}
               ]}] == result
   end
 
@@ -55,9 +55,11 @@ defmodule Greenbar.Tags.AttachmentTest do
 _~$thing~_
 ~end~
 """, %{"things" => ["a","b","c","d"]})
-    assert [%{children: [], fields: [], name: :attachment}, %{name: :italics, text: "a"},
-            %{name: :newline}, %{name: :italics, text: "b"}, %{name: :newline},
-            %{name: :italics, text: "c"}, %{name: :newline}, %{name: :italics, text: "d"}] == result
+    assert [%{children: [], fields: [], name: :attachment},
+            %{name: :paragraph, children: [%{name: :italics, text: "a"},
+                                           %{name: :italics, text: "b"},
+                                           %{name: :italics, text: "c"},
+                                           %{name: :italics, text: "d"}]}] == result
   end
 
   test "attachment with empty body and attrs with other template content", context do
@@ -71,11 +73,11 @@ _~$thing~_
       """, %{})
     assert [%{children: [], color: "red", fields: [], name: :attachment,
               title: "Testing 123"},
-            %{children: [%{children: [%{name: :text, text: "One"}, %{name: :newline}],
+            %{children: [%{children: [%{name: :text, text: "One"}],
                            name: :list_item},
-                         %{children: [%{name: :text, text: "Two"}, %{name: :newline}],
+                         %{children: [%{name: :text, text: "Two"}],
                            name: :list_item},
-                         %{children: [%{name: :text, text: "Three"}, %{name: :newline}],
+                         %{children: [%{name: :text, text: "Three"}],
                            name: :list_item}], name: :unordered_list}] == result
   end
 
@@ -115,7 +117,8 @@ _~$thing~_
               pretext: "pretext",
               fields: [],
               children: [
-                %{name: :text, text: "body"}
+                %{name: :paragraph,
+                  children: [%{name: :text, text: "body"}]}
               ]}] == result
   end
 

--- a/test/greenbar/tags/join_test.exs
+++ b/test/greenbar/tags/join_test.exs
@@ -18,7 +18,7 @@ defmodule Greenbar.Tags.JoinTest do
                            "~join var=$stuff~~$item~~end~",
                            %{"stuff" => ["foo", "bar", "baz"]})
 
-    assert [%{name: :text, text: "foo, bar, baz"}] == result
+    assert [%{name: :paragraph, children: [%{name: :text, text: "foo, bar, baz"}]}] == result
   end
 
   test "simple join with non-default joiner", context do
@@ -27,7 +27,7 @@ defmodule Greenbar.Tags.JoinTest do
                            "~join var=$stuff with=\"-\" ~~$item~~end~",
                            %{"stuff" => ["foo", "bar", "baz"]})
 
-    assert [%{name: :text, text: "foo-bar-baz"}] == result
+    assert [%{name: :paragraph, children: [%{name: :text, text: "foo-bar-baz"}]}] == result
   end
 
   test "join with a body", context  do
@@ -38,7 +38,7 @@ defmodule Greenbar.Tags.JoinTest do
                                          %{"name" => "moe"},
                                          %{"name" => "curly"}]})
 
-    assert [%{name: :text, text: "larry, moe, curly"}] == result
+    assert [%{name: :paragraph, children: [%{name: :text, text: "larry, moe, curly"}]}] == result
   end
 
   test "join with single input", context do
@@ -47,7 +47,7 @@ defmodule Greenbar.Tags.JoinTest do
                            "~join var=$stuff~~$item~~end~",
                            %{"stuff" => ["highlander"]})
 
-    assert [%{name: :text, text: "highlander"}] == result
+    assert [%{name: :paragraph, children: [%{name: :text, text: "highlander"}]}] == result
   end
 
   test "nested joins", context do
@@ -58,6 +58,7 @@ defmodule Greenbar.Tags.JoinTest do
                                          ["four", "five", "six"],
                                          ["seven", "eight", "nine"]]})
 
-    assert [%{name: :text, text: "one, two, three-four, five, six-seven, eight, nine"}] == result
+    assert [%{name: :paragraph, children: [
+                 %{name: :text, text: "one, two, three-four, five, six-seven, eight, nine"}]}] == result
   end
 end

--- a/test/markdown_test.exs
+++ b/test/markdown_test.exs
@@ -80,4 +80,14 @@ a test
     assert output === [%{name: :paragraph, children: [%{name: :text, text: "foo"}]}]
   end
 
+  test "empty link titles don't trigger a crash" do
+    {:ok, output} = Markdown.analyze("[](here)")
+    assert output === [%{name: :paragraph, children: [%{name: :link, text: "", url: "here"}]}]
+  end
+
+  test "empty link urls don't trigger a crash" do
+    {:ok, output} = Markdown.analyze("[foo]()")
+    assert output === [%{name: :paragraph, children: [%{name: :link, text: "foo", url: ""}]}]
+  end
+
 end

--- a/test/markdown_test.exs
+++ b/test/markdown_test.exs
@@ -5,25 +5,27 @@ defmodule Greenbar.MarkdownTest do
   use ExUnit.Case
 
   test "italics are parsed correctly" do
-    {:ok, output} = Markdown.analyze("This is a test.\n_foo_\n")
-    assert output === [%{name: :text, text: "This is a test."},
-                       %{name: :newline},
-                       %{name: :italics, text: "foo"},
-                       %{name: :newline}]
+    {:ok, output} = Markdown.analyze("This is a test.\n\n_foo_\n")
+    assert output === [%{name: :paragraph, children: [%{name: :text, text: "This is a test."}]},
+                       %{name: :paragraph, children: [%{name: :italics, text: "foo"}]}]
   end
 
   test "boldface are parsed correctly" do
-    {:ok, output} = Markdown.analyze("This is a test.\n__foo__\n")
-    assert output === [%{name: :text, text: "This is a test."},
-                       %{name: :newline},
-                       %{name: :bold, text: "foo"},
-                       %{name: :newline}]
+    {:ok, output} = Markdown.analyze("This is a test.\n\n__foo__\n")
+    assert output === [%{name: :paragraph, children: [%{name: :text, text: "This is a test."}]},
+                       %{name: :paragraph, children: [%{name: :bold, text: "foo"}]}]
+  end
+
+  test "paragraphs are parsed correctly" do
+    {:ok, output} = Markdown.analyze("This is a test.\n\n\n__foo__\n\n\nThis is another test.\n")
+    assert output === [%{name: :paragraph, children: [%{name: :text, text: "This is a test."}]},
+                       %{name: :paragraph, children: [%{name: :bold, text: "foo"}]},
+                       %{name: :paragraph, children: [%{name: :text, text: "This is another test."}]}]
   end
 
   test "single line code blocks are parsed correctly" do
     {:ok, output} = Markdown.analyze("`This is a test`")
-    assert output === [%{name: :fixed_width, text: "This is a test"},
-                       %{name: :newline}]
+    assert output === [%{name: :paragraph, children: [%{name: :fixed_width, text: "This is a test"}]}]
   end
 
   test "multi line code blocks are parsed correctly" do
@@ -47,36 +49,35 @@ a test
   end
 
   test "links are parsed correctly" do
-    {:ok, output} = Markdown.analyze("[operable](https://operable.io)")
-    assert output === [%{name: :link,
-                         text: "operable",
-                         url: "https://operable.io"},
-                       %{name: :newline}]
+    {:ok, output} = Markdown.analyze("Click on [operable](https://operable.io) to learn more about Cog.\n")
+    assert output === [%{name: :paragraph, children: [%{name: :text, text: "Click on "},
+                                                      %{name: :link, text: "operable", url: "https://operable.io"},
+                                                      %{name: :text, text: " to learn more about Cog."}]}]
   end
 
   test "unordered lists are parsed correctly" do
     {:ok, output} = Markdown.analyze("* One\n* Two\n* Three\n")
-    assert output === [%{children: [%{children: [%{name: :text, text: "One"}, %{name: :newline}],
+    assert output === [%{children: [%{children: [%{name: :text, text: "One"}],
                                       name: :list_item},
-                                    %{children: [%{name: :text, text: "Two"}, %{name: :newline}],
+                                    %{children: [%{name: :text, text: "Two"}],
                                       name: :list_item},
-                                    %{children: [%{name: :text, text: "Three"}, %{name: :newline}],
+                                    %{children: [%{name: :text, text: "Three"}],
                                       name: :list_item}], name: :unordered_list}]
   end
 
   test "ordered lists are parsed correctly" do
     {:ok, output} = Markdown.analyze("1. Abc\n1. Def\n1. _Ghi_\n")
-    assert output === [%{children: [%{children: [%{name: :text, text: "Abc"}, %{name: :newline}],
+    assert output === [%{children: [%{children: [%{name: :text, text: "Abc"}],
                                       name: :list_item},
-                                    %{children: [%{name: :text, text: "Def"}, %{name: :newline}],
+                                    %{children: [%{name: :text, text: "Def"}],
                                       name: :list_item},
-                                    %{children: [%{name: :italics, text: "Ghi"}, %{name: :newline}],
+                                    %{children: [%{name: :italics, text: "Ghi"}],
                                       name: :list_item}], name: :ordered_list}]
   end
 
   test "codeblocks don't nest" do
     {:ok, output} = Markdown.analyze("```\n```\nfoo\n```\n```\n")
-    assert output === [%{name: :text, text: "foo"}, %{name: :newline}]
+    assert output === [%{name: :paragraph, children: [%{name: :text, text: "foo"}]}]
   end
 
 end

--- a/test/markdown_test.exs
+++ b/test/markdown_test.exs
@@ -77,7 +77,7 @@ a test
 
   test "codeblocks don't nest" do
     {:ok, output} = Markdown.analyze("```\n```\nfoo\n```\n```\n")
-    assert output === [%{name: :paragraph, children: [%{name: :text, text: "foo"}]}]
+    assert output === [%{name: :paragraph, children: [%{name: :text, text: "foo"}, %{name: :newline}]}]
   end
 
   test "empty link titles don't trigger a crash" do

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -49,7 +49,7 @@ defmodule Greenbar.ParserTest do
 
   test "solo variables are parsed", context do
     {:ok, template} = Engine.parse(context.engine, Templates.solo_variable)
-    [{:text, "This is a test.\n"}, {:var, "item", nil}, {:text, ".\n"}] = template
+    [{:text, "This is a test.\n\n"}, {:var, "item", nil}, {:text, ".\n"}] = template
   end
 
   test "comments w/o terminating newlines are parsed", context do

--- a/test/support/assertions.ex
+++ b/test/support/assertions.ex
@@ -27,4 +27,17 @@ defmodule Greenbar.Test.Support.Assertions do
     end
   end
 
+  def extract_names(result) do
+    extract_names(result, [])
+  end
+
+  def extract_names([], accum), do: Enum.reverse(accum)
+  def extract_names([%{name: name, children: children}|t], accum) do
+    children = extract_names(children)
+    extract_names(t, [{name, children}|accum])
+  end
+  def extract_names([%{name: name}|t], accum) do
+    extract_names(t, [name|accum])
+  end
+
 end

--- a/test/support/templates.ex
+++ b/test/support/templates.ex
@@ -25,6 +25,7 @@ defmodule Greenbar.Test.Support.Templates do
   def solo_variable do
     """
 This is a test.
+
 ~$item~.
 """
   end
@@ -45,7 +46,9 @@ This has been a test.
     """
 This is a test. There are ~count var=$items~ items.
 ~each var=$items~
+
   `~$item~`
+
 ~end~
 
 
@@ -160,14 +163,12 @@ No user creators available.
 
   def nested_lists do
     """
-~each var=$groups as=group~
-
-* ~$group.name~
-~each var=$group.users as=user~
-
-  1. ~$user.name~
-~end~
-~end~
+    ~each var=$groups as=group~
+    * ~$group.name~
+    ~each var=$group.users as=user~
+      1. ~$user.name~
+    ~end~
+    ~end~
     """
   end
 

--- a/test/support/test_case.ex
+++ b/test/support/test_case.ex
@@ -4,6 +4,7 @@ defmodule Greenbar.Test.Support.TestCase do
     quote do
         require Greenbar.Test.Support.Assertions
 
+        import Greenbar.Test.Support.Assertions, only: [extract_names: 1]
         alias Greenbar.Test.Support.Assertions
         alias Greenbar.Test.Support.Templates
         alias Greenbar.Engine


### PR DESCRIPTION
Newlines inside paragraphs will generate hard line breaks. This is a departure from "standard" Markdown which requires an invisible delimiter (two spaces followed by a newline) for the same behavior.

See operable/greenbar_markdown#7