### PR TITLE
Don't render fixed-width as fixed-width in tables

### DIFF
--- a/test/greenbar/renderers/hipchat_processor_test.exs
+++ b/test/greenbar/renderers/hipchat_processor_test.exs
@@ -140,4 +140,33 @@ defmodule Greenbar.Test.Test.HipChatRendererTest do
 
     assert expected == rendered
   end
+
+    test "handles table cells that have fixed-width formatting" do
+    directives = [%{"name" => "table",
+                   "children" => [%{"name" => "table_header",
+                                    "children" => [
+                                      %{"name" => "table_cell",
+                                        "children" => [
+                                          %{"name" => "text",
+                                            "text" => "Foo"}]}]},
+                                  %{"name" => "table_row",
+                                    "children" => [
+                                      %{"name" => "table_cell",
+                                        "children" => [
+                                          %{"name" => "fixed_width",
+                                            "text" => "Hello World"}]}]}]}]
+
+    rendered = HipChatRenderer.render(directives)
+    expected = """
+    <pre>+-------------+
+    | Foo         |
+    +-------------+
+    | Hello World |
+    +-------------+
+    </pre>
+    """ |> String.strip
+
+    assert expected == rendered
+  end
+
 end

--- a/test/greenbar/renderers/slack_processor_test.exs
+++ b/test/greenbar/renderers/slack_processor_test.exs
@@ -144,4 +144,33 @@ defmodule Greenbar.Test.SlackRendererTest do
 
     assert expected == rendered
   end
+
+  test "handles table cells that have fixed-width formatting" do
+    directives = [%{"name" => "table",
+                   "children" => [%{"name" => "table_header",
+                                    "children" => [
+                                      %{"name" => "table_cell",
+                                        "children" => [
+                                          %{"name" => "text",
+                                            "text" => "Foo"}]}]},
+                                  %{"name" => "table_row",
+                                    "children" => [
+                                      %{"name" => "table_cell",
+                                        "children" => [
+                                          %{"name" => "fixed_width",
+                                            "text" => "Hello World"}]}]}]}]
+
+    {rendered, _} = SlackRenderer.render(directives)
+    expected = """
+    ```+-------------+
+    | Foo         |
+    +-------------+
+    | Hello World |
+    +-------------+
+    ```
+    """ |> String.strip
+
+    assert expected == rendered
+  end
+
 end


### PR DESCRIPTION
Adds context to HipChat `process_directive` calls (just like for Slack)
so we can know to not render fixed-width code when it's inside a
fixed-width block, like our tables.

(We already had context in the Slack renderer, so we
do the same thing there.)

HipChat will remove `<code>` tags that appear inside `<pre>` blocks,
which can throws off the padding in our rendered tables. In Slack,
without this code, we'd see the tick-marks, which isn't a huge deal
overall, but is annoying.

Fixes operable/cog#1239