### PR TITLE
Parse boolean values for use in tags

### DIFF
--- a/lib/greenbar/compiler/tag_attrs.ex
+++ b/lib/greenbar/compiler/tag_attrs.ex
@@ -16,7 +16,7 @@ defmodule Greenbar.Compiler.TagAttributes do
   defp build_attr_exprs([], attr_expr) do
     attr_expr
   end
-  defp build_attr_exprs([{:assign_tag_attr, attr_name, {type, _, value}}|t], expr) when type in [:integer, :float, :string] do
+  defp build_attr_exprs([{:assign_tag_attr, attr_name, {type, _, value}}|t], expr) when type in [:integer, :float, :string, :boolean] do
     expr = Macro.pipe(attrs_pipe_start(expr), quote do Map.put(unquote(attr_name), unquote(value)) end, 0)
     build_attr_exprs(t, expr)
   end
@@ -71,7 +71,7 @@ defmodule Greenbar.Compiler.TagAttributes do
 
   # equal
   defp build_attr_exprs([{:assign_tag_attr, attr_name, {:equal, {:var, name, ops},
-                                                        {type, _, value}}}|t], expr) when type in [:integer, :float, :string] do
+                                                        {type, _, value}}}|t], expr) when type in [:integer, :float, :string, :boolean] do
     expr = Macro.pipe(attrs_pipe_start(expr), quote do
                        Map.put(unquote(attr_name),
                        (Kernel.==(Greenbar.Runtime.var_to_value(scope, unquote(name), unquote(ops)), unquote(value))))
@@ -81,7 +81,7 @@ defmodule Greenbar.Compiler.TagAttributes do
 
   # not equal
   defp build_attr_exprs([{:assign_tag_attr, attr_name, {:not_equal, {:var, name, ops},
-                                                        {type, _, value}}}|t], expr) when type in [:integer, :float, :string] do
+                                                        {type, _, value}}}|t], expr) when type in [:integer, :float, :string, :boolean] do
     expr = Macro.pipe(attrs_pipe_start(expr), quote do
                        Map.put(unquote(attr_name),
                        (Kernel.!==(Greenbar.Runtime.var_to_value(scope, unquote(name), unquote(ops)), unquote(value))))

--- a/src/gb_expr_lexer.xrl
+++ b/src/gb_expr_lexer.xrl
@@ -6,6 +6,7 @@ FLOAT                   = [0-9]+\.[0-9]+
 STRING                  = "(\\\^.|\\.|[^"])*"
 VAR                     = \$[a-zA-Z][a-zA-Z0-9_]*
 EXPR_NAME               = [a-zA-Z][a-zA-Z0-9_\-]*
+BOOLEAN                 = false|true
 ASSIGN                  = \=
 GREATER_THAN            = >
 GREATER_THAN_EQ         = >\=
@@ -26,6 +27,7 @@ SKIPPED                 = \s
 Rules.
 
 {EXPR_END}              : {token, {expr_end, TokenLine, <<"end">>}}.
+{BOOLEAN}               : {token, {boolean, TokenLine, boolean(TokenChars)}}.
 {EXPR_NAME}             : {token, parse_maybe_tag(TokenLine, ?_ES(TokenChars))}.
 {INTEGER}               : {token, {integer, TokenLine, ?_INT(TokenChars)}}.
 {FLOAT}                 : {token, {float, TokenLine, ?_FLOAT(TokenChars)}}.
@@ -99,3 +101,8 @@ is_tag(Name) ->
 
 strip_quotes(Text) ->
   re:replace(Text, "(^\"|\"$)", "", [global, {return, binary}]).
+
+boolean("true") ->
+  true;
+boolean("false") ->
+  false.

--- a/src/gb_parser.yrl
+++ b/src/gb_parser.yrl
@@ -1,6 +1,6 @@
 Terminals
 
-text integer float string var
+text integer float boolean string var
 
 dot lbracket rbracket lparen rparen
 
@@ -78,6 +78,8 @@ tag_attr ->
 tag_attr ->
   attr_name assign float : {assign_tag_attr, '$1', '$3'}.
 tag_attr ->
+  attr_name assign boolean : {assign_tag_attr, '$1', '$3'}.
+tag_attr ->
   attr_name assign string : {assign_tag_attr, '$1', '$3'}.
 tag_attr ->
   attr_name assign expr_name : {assign_tag_attr, '$1', name_to_string('$3')}.
@@ -115,6 +117,10 @@ var_expr ->
   var_value equal float : {equal, '$1', '$3'}.
 var_expr ->
   var_value not_equal float : {not_equal, '$1', '$3'}.
+var_expr ->
+  var_value equal boolean : {equal, '$1', '$3'}.
+var_expr ->
+  var_value not_equal boolean : {not_equal, '$1', '$3'}.
 var_expr ->
   var_value gt var_value : {gt, '$1', '$3'}.
 var_expr ->

--- a/test/greenbar/tags/if_test.exs
+++ b/test/greenbar/tags/if_test.exs
@@ -21,6 +21,15 @@ defmodule Greenbar.Tags.IfTest do
     assert [%{name: :paragraph, children: [%{name: :text, text: "It worked!"}]}] == result
   end
 
+  test "boolean equality", context do
+    result = eval_template(context.engine,
+                           "boolean_equality",
+                           ~s[~if cond=$stuff == false~It's false!~end~],
+                           %{"stuff" => false})
+
+    assert [%{name: :paragraph, children: [%{name: :text, text: "It's false!"}]}] == result
+  end
+
   test "integer greater than", context do
     result = eval_template(context.engine,
                            "integer_greater_than",

--- a/test/greenbar/tags/if_test.exs
+++ b/test/greenbar/tags/if_test.exs
@@ -1,0 +1,39 @@
+defmodule Greenbar.Tags.IfTest do
+  use Greenbar.Test.Support.TestCase
+  alias Greenbar.Engine
+
+  setup_all do
+    {:ok, engine} = Engine.new
+    [engine: engine]
+  end
+
+  defp eval_template(engine, name, template, args) do
+    engine = Engine.compile!(engine, name, template)
+    Engine.eval!(engine, name, scope: args)
+  end
+
+  test "string equality", context do
+    result = eval_template(context.engine,
+                           "string_equality",
+                           ~s[~if cond=$stuff == "stuff"~It worked!~end~],
+                           %{"stuff" => "stuff"})
+
+    assert [%{name: :paragraph, children: [%{name: :text, text: "It worked!"}]}] == result
+  end
+
+  test "integer greater than", context do
+    result = eval_template(context.engine,
+                           "integer_greater_than",
+                           ~s[~if cond=$num > 5~It's greater!~end~],
+                           %{"num" => 6})
+
+    assert [%{name: :paragraph, children: [%{name: :text, text: "It's greater!"}]}] == result
+
+    result = eval_template(context.engine,
+                           "integer_greater_than",
+                           ~s[~if cond=$num > 5~It's greater!~end~],
+                           %{"num" => 4})
+
+    assert [] == result
+  end
+end


### PR DESCRIPTION
Adds support for using `true` or `false` as tag attributes. Needed for templates like the following:

```
~if $bundle.enabled == true~
Enabled
~end~
~if $bundle.enabled == false~
Disabled
~end~
```