### PR TITLE
Don't drop newlines following a join tag

### DIFF
--- a/src/gb_parser.yrl
+++ b/src/gb_parser.yrl
@@ -224,6 +224,7 @@ ensure_list(Value) when is_list(Value) -> Value;
 ensure_list(Value) -> [Value].
 
 maybe_drop_leading_eol({body_tag, _, <<"if">>}, Rest) -> Rest;
+maybe_drop_leading_eol({body_tag, _, <<"join">>}, Rest) -> Rest;
 maybe_drop_leading_eol(_Tag, Rest) -> drop_leading_eol(Rest).
 
 drop_leading_eol({text, <<"\n">>}) -> [];

--- a/test/greenbar/tags/join_test.exs
+++ b/test/greenbar/tags/join_test.exs
@@ -61,4 +61,28 @@ defmodule Greenbar.Tags.JoinTest do
     assert [%{name: :paragraph, children: [
                  %{name: :text, text: "one, two, three-four, five, six-seven, eight, nine"}]}] == result
   end
+
+  test "join inside an each", context do
+    result = eval_template(context.engine,
+                           "join_inside_an_each",
+                           """
+                           ~each var=$people as=person~
+                           **Name:** ~$person.name~
+                           **Mech Keyboards:** ~join var=$person.mech_keyboards with=", "~~$item.name~~end~
+                           ~end~
+                           """,
+                           %{"people" => [%{"name" => "Shelton",
+                                            "mech_keyboards" => []},
+                                          %{"name" => "Mark",
+                                            "mech_keyboards" => [%{"name" => "Ergodox"}]},
+                                          %{"name" => "Patrick",
+                                            "mech_keyboards" => [%{"name" => "MiniVan"}]}]})
+
+    assert [%{name: :paragraph, children: [%{name: :bold, text: "Name:"}, %{name: :text, text: " Shelton"}, %{name: :newline},
+                                           %{name: :bold, text: "Mech Keyboards:"}, %{name: :text, text: " "}, %{name: :newline},
+                                           %{name: :bold, text: "Name:"}, %{name: :text, text: " Mark"}, %{name: :newline},
+                                           %{name: :bold, text: "Mech Keyboards:"}, %{name: :text, text: " Ergodox"}, %{name: :newline},
+                                           %{name: :bold, text: "Name:"}, %{name: :text, text: " Patrick"}, %{name: :newline},
+                                           %{name: :bold, text: "Mech Keyboards:"}, %{name: :text, text: " MiniVan"}]}] = result
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/operable/cog/issues/1271

The gist is this is that we were removing newlines following a tag which would jam results of rendering an each block if a join tag was at the bottom.

An example:

```
~each var=$people as=person~
**Name:** ~$person.name~
**Mech Keyboards:** ~join var=$person.mech_keyboards with=", "~~$item.name~~end~
~end~
```

Would render:

```
*Name:* Shelton
*Mech Keyboards:* *Name:* Mark
*Mech Keyboards:* Ergodox**Name:** Patrick
*Mech Keyboards:* MiniVan
```

And now it renders the correct thing:

```
*Name:* Shelton
*Mech Keyboards:*
*Name:* Mark
*Mech Keyboards:* Ergodox*
*Name:** Patrick
*Mech Keyboards:* MiniVan
```