### PR TITLE
Omit newline when rendering a single line attachment in hipchat

### DIFF
--- a/lib/greenbar/renderers/hipchat.ex
+++ b/lib/greenbar/renderers/hipchat.ex
@@ -26,7 +26,12 @@ defmodule Greenbar.Renderers.HipChatRenderer do
     |> Enum.reduce([], &(render_attachment(&1, &2, attachment)))
     |> List.flatten
     |> Enum.join
-    rendered_body <> "<br/>"
+
+    if length(Regex.scan(~r/<br\/>/, rendered_body)) > 1 do
+      rendered_body <> "<br/>"
+    else
+      rendered_body
+    end
   end
   defp process_directive(%{"name" => "text", "text" => text}, _),
     do: text

--- a/test/greenbar/renderers/hipchat_processor_test.exs
+++ b/test/greenbar/renderers/hipchat_processor_test.exs
@@ -141,7 +141,7 @@ defmodule Greenbar.Test.Test.HipChatRendererTest do
     assert expected == rendered
   end
 
-    test "handles table cells that have fixed-width formatting" do
+  test "handles table cells that have fixed-width formatting" do
     directives = [%{"name" => "table",
                    "children" => [%{"name" => "table_header",
                                     "children" => [
@@ -169,4 +169,54 @@ defmodule Greenbar.Test.Test.HipChatRendererTest do
     assert expected == rendered
   end
 
+
+  test "omits a newline after attachments that are each a single line of output" do
+    directives = [%{"name" => "attachment",
+                    "fields" => [],
+                    "children" => [%{"name" => "text", "text" => "Attachment 1"}]},
+                  %{"name" => "attachment",
+                    "fields" => [],
+                    "children" => [%{"name" => "text", "text" => "Attachment 2"}]},
+                  %{"name" => "attachment",
+                    "fields" => [],
+                    "children" => [%{"name" => "text", "text" => "Attachment 3"}]},
+                  %{"name" => "attachment",
+                    "fields" => [],
+                    "children" => [%{"name" => "text", "text" => "Attachment 4"},
+                                   %{"name" => "newline"},
+                                   %{"name" => "text", "text" => "Plus a newline"}]},
+                  %{"name" => "attachment",
+                    "fields" => [],
+                    "children" => [%{"name" => "text", "text" => "Attachment 5"},
+                                   %{"name" => "newline"},
+                                   %{"name" => "text", "text" => "Plus a newline"}]},
+                  %{"name" => "attachment",
+                    "fields" => [],
+                    "children" => [%{"name" => "text", "text" => "Attachment 6"}]},
+                  %{"name" => "text",
+                    "text" => "Random text"},
+                  %{"name" => "newline"},
+                  %{"name" => "attachment",
+                    "fields" => [],
+                    "children" => [%{"name" => "text", "text" => "Attachment 7"}]}]
+
+    expected = """
+    Attachment 1<br/>
+    Attachment 2<br/>
+    Attachment 3<br/>
+    Attachment 4<br/>
+    Plus a newline<br/>
+    <br/>
+    Attachment 5<br/>
+    Plus a newline<br/>
+    <br/>
+    Attachment 6<br/>
+    Random text<br/>
+    Attachment 7
+    """ |> String.replace("\n", "")
+
+    rendered = HipChatRenderer.render(directives)
+
+    assert expected == rendered
+  end
 end


### PR DESCRIPTION
This allows us to render templates like the following in HipChat (new output at the bottom):

```
~each var=$bundles~
~attachment~
~$item.name~
~end~
~end~
```

Old output:

```
cfn

ec2

heroku

operable
```

New output:

```
cfn
ec2
heroku
operable
```

<img width="222" alt="screen shot 2016-12-21 at 4 49 12 pm" src="https://cloud.githubusercontent.com/assets/228734/21407262/9c365832-c79d-11e6-8685-a7e1b9a5615a.png">


Multi-line attachments still include an extra newline between them.

<img width="374" alt="screen shot 2016-12-21 at 4 50 07 pm" src="https://cloud.githubusercontent.com/assets/228734/21407250/8fde85fa-c79d-11e6-827c-20a26085d52a.png">
