### PR TITLE
Tokenize and include newlines in tag parsing rules

### DIFF
--- a/lib/greenbar/compiler.ex
+++ b/lib/greenbar/compiler.ex
@@ -21,6 +21,11 @@ defmodule Greenbar.Compiler do
       buffer = Render.text(buffer, text)
     end
   end
+  def emit({:newline, text}) do
+    quote bind_quoted: [text: text] do
+      buffer = Render.text(buffer, text)
+    end
+  end
   def emit(:eol) do
     quote do
       buffer = Render.eol(buffer)

--- a/lib/greenbar/engine.ex
+++ b/lib/greenbar/engine.ex
@@ -24,6 +24,11 @@ defmodule Greenbar.Engine do
 
   def compile!(%__MODULE__{}=engine, name, source, opts \\ []) do
     source = Enum.join([String.trim(source), "\n"])
+
+    # Used to identify back-to-back tags while parsing as newlines are reduced
+    # out when parsing the first tag
+    source = Regex.replace(~r/~end~\n/, source, "\\0%%END_OF_COLLAPSIBLE_BODY_TAG%%")
+
     hash = :crypto.hash(:sha256, source) |> Base.encode16(case: :lower)
     if should_compile?(engine, name, hash, opts) do
       case :gb_parser.scan_and_parse(source, engine) do

--- a/src/gb_lexer.xrl
+++ b/src/gb_lexer.xrl
@@ -1,14 +1,18 @@
 Definitions.
 
-TEMPLATE_EXPR           = ~(\\~|"|[^~])+~
-COMMENT                 = #(.)*(\n|\r\n)
-TEXT                    = (\\#|\\~|[^#~])+
+TEMPLATE_EXPR               = ~(\\~|"|[^~])+~
+COMMENT                     = #(.)*(\n|\r\n)
+NEWLINE                     = (\n|\r\n)
+END_OF_COLLAPSIBLE_BODY_TAG = %%END_OF_COLLAPSIBLE_BODY_TAG%%
+TEXT                        = (\\#|\\~|[^#~\n\r\%])+
 
 Rules.
 
-{COMMENT}               : skip_token.
-{TEMPLATE_EXPR}         : {token, {tag_expr, TokenLine, unwrap_expr(TokenChars)}}.
-{TEXT}                  : {token, {text, TokenLine, ?_ES(TokenChars)}}.
+{COMMENT}                     : skip_token.
+{TEMPLATE_EXPR}               : {token, {tag_expr, TokenLine, unwrap_expr(TokenChars)}}.
+{NEWLINE}                     : {token, {newline, TokenLine, ?_ES(TokenChars)}}.
+{END_OF_COLLAPSIBLE_BODY_TAG} : {token, {end_of_collapsible_body_tag, TokenLine, ?_ES(TokenChars)}}.
+{TEXT}                        : {token, {text, TokenLine, ?_ES(TokenChars)}}.
 
 Erlang code.
 

--- a/src/gb_parser.yrl
+++ b/src/gb_parser.yrl
@@ -10,9 +10,13 @@ assign empty not_empty gt gte lt lte equal not_equal bound not_bound.
 
 Nonterminals
 
-template template_exprs tag_attrs tag_attr attr_name var_value var_expr var_ops.
+template template_exprs template_expr tag_attrs tag_attr attr_name var_value var_expr var_ops var_op.
 
 Rootsymbol template.
+
+Nonassoc 100 expr_name.
+Nonassoc 200 tag.
+Nonassoc 300 body_tag.
 
 Expect 2.
 
@@ -20,58 +24,29 @@ template ->
   template_exprs : ensure_list('$1').
 
 template_exprs ->
+  template_expr template_exprs : combine('$1', '$2').
+template_exprs ->
+  '$empty' : nil.
+
+template_expr ->
   text : {text, value_from('$1')}.
-template_exprs ->
-  expr_name : unknown_tag('$1').
-template_exprs ->
+template_expr ->
   expr_name tag_attrs : unknown_tag('$1').
-template_exprs ->
+template_expr ->
   expr_name tag_attrs template_exprs expr_end : unknown_tag('$1').
-template_exprs ->
-  tag : make_tag('$1').
-template_exprs ->
+template_expr ->
   tag tag_attrs : make_tag('$1', '$2').
-template_exprs ->
-  body_tag expr_end : make_tag('$1', [], []).
-template_exprs ->
-  body_tag tag_attrs expr_end : make_tag('$1', '$2', []).
-template_exprs ->
-  body_tag template_exprs expr_end : make_tag('$1', [], '$2').
-template_exprs ->
+template_expr ->
   body_tag tag_attrs template_exprs expr_end : make_tag('$1', '$2', '$3').
-template_exprs ->
+template_expr ->
   var_value : '$1'.
-template_exprs ->
+template_expr ->
   eol : eol.
-template_exprs ->
-  text template_exprs : combine({text, value_from('$1')}, '$2').
-template_exprs ->
-  expr_name template_exprs : unknown_tag('$1').
-template_exprs ->
-  expr_name tag_attrs template_exprs : unknown_tag('$1').
-template_exprs ->
-  expr_name tag_attrs template_exprs expr_end template_exprs : unknown_tag('$1').
-template_exprs ->
-  tag template_exprs : combine(make_tag('$1'), '$2').
-template_exprs ->
-  tag tag_attrs template_exprs : combine(make_tag('$1', '$2'), '$3').
-template_exprs ->
-  body_tag expr_end template_exprs : combine(make_tag('$1', [], []), maybe_drop_leading_eol('$1', '$3')).
-template_exprs ->
-  body_tag tag_attrs expr_end template_exprs : combine(make_tag('$1', '$2', []), maybe_drop_leading_eol('$1', '$4')).
-template_exprs ->
-  body_tag template_exprs expr_end template_exprs : combine(make_tag('$1', [], '$2'), maybe_drop_leading_eol('$1', '$4')).
-template_exprs ->
-  body_tag tag_attrs template_exprs expr_end template_exprs : combine(make_tag('$1', '$2', '$3'), maybe_drop_leading_eol('$1', '$5')).
-template_exprs ->
-  var_value template_exprs : combine('$1', '$2').
-template_exprs ->
-  eol template_exprs : combine(eol, '$2').
 
 tag_attrs ->
-  tag_attr : '$1'.
-tag_attrs ->
   tag_attr tag_attrs : combine('$1', '$2').
+tag_attrs ->
+  '$empty' : nil.
 
 tag_attr ->
   attr_name assign integer : {assign_tag_attr, '$1', '$3'}.
@@ -151,22 +126,19 @@ var_expr ->
   var_value not_bound : {not_bound, '$1'}.
 
 var_value ->
-  var : make_var(value_from('$1')).
-var_value ->
   var var_ops : make_var(value_from('$1'), '$2').
-var_value ->
-  expr_name lparen var rparen : make_var(value_from('$3'), [make_funcall('$1')]).
 var_value ->
   expr_name lparen var var_ops rparen : make_var(value_from('$3'), combine('$4', make_funcall('$1'))).
 
 var_ops ->
-  dot expr_name : [{key, value_from('$2')}].
+  var_op var_ops : combine('$1', '$2').
 var_ops ->
-  lbracket integer rbracket : [{index, value_from('$2')}].
-var_ops ->
-  dot expr_name var_ops : [{key, value_from('$2')}] ++ '$3'.
-var_ops ->
-  lbracket integer rbracket var_ops : [{index, value_from('$2')}] ++ '$4'.
+  '$empty': nil.
+
+var_op ->
+  dot expr_name : {key, value_from('$2')}.
+var_op ->
+  lbracket integer rbracket : {index, value_from('$2')}.
 
 Erlang code.
 
@@ -197,24 +169,26 @@ scan_and_parse(Text, Engine) when is_binary(Text) ->
     erlang:erase(greenbar_engine)
   end.
 
-combine(A, B) when is_list(A),
-                   is_list(B) ->
-  [A] ++ B;
+combine(nil, B) -> combine([], B);
+combine(A, nil) -> combine(A, []);
+combine(A, B) when is_list(A), is_list(B) -> A ++ B;
 combine(A, B) when is_list(A) -> A ++ [B];
 combine(A, B) when is_list(B) -> [A|B];
 combine(A, B) -> [A, B].
 
 value_from({_, _, Text}) -> Text.
 
-make_tag(Name) -> {tag, value_from(Name), nil, nil}.
+make_tag(Name, nil) -> {tag, value_from(Name), nil, nil};
 make_tag(Name, Attrs) -> {tag, value_from(Name), ensure_list(Attrs), nil}.
+
 make_tag({body_tag, _, <<"if">>}=Name, Attrs, Body) ->
   {tag, value_from(Name), ensure_list(Attrs), ensure_list(Body)};
+make_tag(Name, nil, Body) -> make_tag(Name, [], Body);
+make_tag(Name, Attrs, nil) -> make_tag(Name, Attrs, []);
 make_tag(Name, Attrs, Body) ->
   Body1 = drop_leading_eol(Body),
   {tag, value_from(Name), ensure_list(Attrs), ensure_list(Body1)}.
 
-make_var(Name) -> {var, Name, nil}.
 make_var(Name, Ops) -> {var, Name, Ops}.
 
 make_funcall({_, _, Name}) ->
@@ -222,10 +196,6 @@ make_funcall({_, _, Name}) ->
 
 ensure_list(Value) when is_list(Value) -> Value;
 ensure_list(Value) -> [Value].
-
-maybe_drop_leading_eol({body_tag, _, <<"if">>}, Rest) -> Rest;
-maybe_drop_leading_eol({body_tag, _, <<"join">>}, Rest) -> Rest;
-maybe_drop_leading_eol(_Tag, Rest) -> drop_leading_eol(Rest).
 
 drop_leading_eol({text, <<"\n">>}) -> [];
 drop_leading_eol([{text, <<"\n">>}|T]) -> T;

--- a/test/greenbar/tags/if_test.exs
+++ b/test/greenbar/tags/if_test.exs
@@ -45,4 +45,34 @@ defmodule Greenbar.Tags.IfTest do
 
     assert [] == result
   end
+
+  test "newline removed if single line condition evaluates to false", context do
+    result = eval_template(context.engine,
+                           "single_line_if",
+                           """
+                           Cheeseburger
+                           ~if cond=$pizza bound?~Pizza~end~
+                           Lasagna
+                           """,
+                           %{})
+
+    assert [%{name: :paragraph, children: [%{name: :text, text: "Cheeseburger"},
+                                           %{name: :newline},
+                                           %{name: :text, text: "Lasagna"}]}] == result
+
+    result = eval_template(context.engine,
+                           "single_line_if",
+                           """
+                           Cheeseburger
+                           ~if cond=$pizza bound?~Pizza~end~
+                           Lasagna
+                           """,
+                           %{"pizza" => true})
+
+    assert [%{name: :paragraph, children: [%{name: :text, text: "Cheeseburger"},
+                                           %{name: :newline},
+                                           %{name: :text, text: "Pizza"},
+                                           %{name: :newline},
+                                           %{name: :text, text: "Lasagna"}]}] == result
+  end
 end

--- a/test/greenbar/tags/join_test.exs
+++ b/test/greenbar/tags/join_test.exs
@@ -83,6 +83,6 @@ defmodule Greenbar.Tags.JoinTest do
                                            %{name: :bold, text: "Name:"}, %{name: :text, text: " Mark"}, %{name: :newline},
                                            %{name: :bold, text: "Mech Keyboards:"}, %{name: :text, text: " Ergodox"}, %{name: :newline},
                                            %{name: :bold, text: "Name:"}, %{name: :text, text: " Patrick"}, %{name: :newline},
-                                           %{name: :bold, text: "Mech Keyboards:"}, %{name: :text, text: " MiniVan"}]}] = result
+                                           %{name: :bold, text: "Mech Keyboards:"}, %{name: :text, text: " MiniVan"}]}] == result
   end
 end

--- a/test/greenbar/whitespace_test.exs
+++ b/test/greenbar/whitespace_test.exs
@@ -1,0 +1,184 @@
+defmodule Greenbar.WhitespaceTest do
+  use Greenbar.Test.Support.TestCase
+  alias Greenbar.Engine
+
+  setup_all do
+    {:ok, engine} = Engine.new
+    [engine: engine]
+  end
+
+  defp eval_template(engine, name, template, args) do
+    engine = Engine.compile!(engine, name, template)
+    Engine.eval!(engine, name, scope: args)
+  end
+
+  test "stripping whitespace around a multiline each tag", context do
+    template = """
+    ~each var=$bundles as=bundle~
+    Bundle: ~$bundle~
+    ~end~
+    """
+
+    actual = eval_template(context.engine, "bundles", template, %{"bundles" => ["ec2", "ecs", "s3"]})
+
+    expected = [%{name: :paragraph,
+                  children: [%{name: :text, text: "Bundle: ec2"},
+                             %{name: :newline},
+                             %{name: :text, text: "Bundle: ecs"},
+                             %{name: :newline},
+                             %{name: :text, text: "Bundle: s3"}]}]
+
+    assert expected == actual
+  end
+
+  test "stripping whitespace around a multiline each tag with surrounding newlines", context do
+    template = """
+    These are the bundles.
+
+    ~each var=$bundles as=bundle~
+    Bundle: ~$bundle~
+    ~end~
+
+    Look at them!
+    """
+
+    actual = eval_template(context.engine, "bundles_with_surrounding_newlines", template, %{"bundles" => ["ec2", "ecs", "s3"]})
+
+    expected = [%{name: :paragraph,
+                  children: [%{name: :text, text: "These are the bundles."}]},
+                %{name: :paragraph,
+                  children: [%{name: :text, text: "Bundle: ec2"},
+                             %{name: :newline},
+                             %{name: :text, text: "Bundle: ecs"},
+                             %{name: :newline},
+                             %{name: :text, text: "Bundle: s3"}]},
+                %{name: :paragraph,
+                  children: [%{name: :text, text: "Look at them!"}]}]
+
+    assert expected == actual
+  end
+
+  test "stripping a single whitespace token around a multiline each tag with surrounding newlines", context do
+    template = """
+    These are the bundles.
+
+    ~each var=$bundles as=bundle~
+    Bundle: ~$bundle~
+
+    ~end~
+
+    Look at them!
+    """
+
+    actual = eval_template(context.engine, "bundle_paragraphs_with_surrounding_newlines", template, %{"bundles" => ["ec2", "ecs", "s3"]})
+
+    expected = [%{name: :paragraph,
+                  children: [%{name: :text, text: "These are the bundles."}]},
+                %{name: :paragraph,
+                  children: [%{name: :text, text: "Bundle: ec2"}]},
+                %{name: :paragraph,
+                  children: [%{name: :text, text: "Bundle: ecs"}]},
+                %{name: :paragraph,
+                  children: [%{name: :text, text: "Bundle: s3"}]},
+                %{name: :paragraph,
+                  children: [%{name: :text, text: "Look at them!"}]}]
+
+    assert expected == actual
+  end
+
+  test "Injecting newlines into an each", context do
+    template = """
+    These are the bundles.
+    ~each var=$bundles as=bundle~Bundle: ~$bundle~~end~
+    Look at them!
+    """
+
+    actual = eval_template(context.engine, "single_line_bundles", template, %{"bundles" => ["ec2", "ecs", "s3"]})
+
+    expected = [%{name: :paragraph,
+                  children: [%{name: :text, text: "These are the bundles."},
+                             %{name: :newline},
+                             %{name: :text, text: "Bundle: ec2"},
+                             %{name: :newline},
+                             %{name: :text, text: "Bundle: ecs"},
+                             %{name: :newline},
+                             %{name: :text, text: "Bundle: s3"},
+                             %{name: :newline},
+                             %{name: :text, text: "Look at them!"}]}]
+
+    assert expected == actual
+
+    actual = eval_template(context.engine, "single_line_bundles", template, %{"bundles" => []})
+
+    expected = [%{name: :paragraph,
+                  children: [%{name: :text, text: "These are the bundles."},
+                             %{name: :newline},
+                             %{name: :text, text: "Look at them!"}]}]
+
+    assert expected == actual
+  end
+
+  test "Injecting newlines into an each on template boundaries", context do
+    template = """
+    ~each var=$bundles as=bundle~Bundle: ~$bundle~~end~
+    """
+
+    actual = eval_template(context.engine, "template_boundary_bundles", template, %{"bundles" => ["ec2", "ecs", "s3"]})
+
+    expected = [%{name: :paragraph,
+                  children: [%{name: :text, text: "Bundle: ec2"},
+                             %{name: :newline},
+                             %{name: :text, text: "Bundle: ecs"},
+                             %{name: :newline},
+                             %{name: :text, text: "Bundle: s3"}]}]
+
+    assert expected == actual
+
+    actual = eval_template(context.engine, "template_boundary_bundles", template, %{"bundles" => []})
+
+    expected = []
+
+    assert expected == actual
+  end
+
+  test "Preserving an inline join", context do
+    template = """
+    I like many things: ~join var=$things~~$item~~end~
+    """
+
+    actual = eval_template(context.engine, "inline_join", template, %{"things" => ["ec2", "ecs", "s3"]})
+
+    expected = [%{name: :paragraph,
+                  children: [%{name: :text, text: "I like many things: ec2, ecs, s3"}]}]
+
+    assert expected == actual
+  end
+
+  test "Back to back tags", context do
+    template = """
+    ~each var=$things~
+    ~$item~
+    ~end~
+    ~each var=$things~
+    ~$item~
+    ~end~
+    """
+
+    actual = eval_template(context.engine, "back_to_back_tags", template, %{"things" => ["ec2", "ecs", "s3"]})
+
+    expected = [%{name: :paragraph,
+                  children: [%{name: :text, text: "ec2"},
+                             %{name: :newline},
+                             %{name: :text, text: "ecs"},
+                             %{name: :newline},
+                             %{name: :text, text: "s3"},
+                             %{name: :newline},
+                             %{name: :text, text: "ec2"},
+                             %{name: :newline},
+                             %{name: :text, text: "ecs"},
+                             %{name: :newline},
+                             %{name: :text, text: "s3"}]}]
+
+    assert expected == actual
+  end
+end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -13,11 +13,9 @@ defmodule Greenbar.ParserTest do
     {:text, "This is a test."} = Enum.at(template, 0)
   end
 
-  test "newlines stay with their parsed text", context do
+  test "newlines are parsed as their own nodes", context do
     {:ok, template} = Engine.parse(context.engine, "This is a \ntest.\n")
-    assert Enum.count(template) == 1
-    text_node = Enum.at(template, 0)
-    assert text_node == {:text, "This is a \ntest.\n"}
+    assert template == [{:text, "This is a "}, {:newline, "\n"}, {:text, "test."}, {:newline, "\n"}]
   end
 
   test "tags w/o bodies are parsed", context do
@@ -32,7 +30,7 @@ defmodule Greenbar.ParserTest do
     assert Enum.count(template) == 1
     {:tag, "each", attrs, body} = Enum.at(template, 0)
     assert [{:assign_tag_attr, "var", {:var, "vms", nil}}] == attrs
-    assert [{:var, "item", [key: "name"]}, {:text, "\n"}] == body
+    assert [{:var, "item", [key: "name"]}, {:newline, "\n"}] == body
   end
 
   test "nested tags are parsed", context do
@@ -41,15 +39,15 @@ defmodule Greenbar.ParserTest do
     {:tag, "each", attrs, body} = Enum.at(template, 0)
     assert [{:assign_tag_attr, "var", {:var, "regions", nil}}] == attrs
     assert {:var, "item", [key: "name"]} = Enum.at(body, 0)
-    {:tag, "each", attrs, body} = Enum.at(body, 2)
+    {:tag, "each", attrs, body} = Enum.at(body, 3)
     assert [{:assign_tag_attr, "var", {:var, "item", [key: "vms"]}}] == attrs
-    assert [{:text, "    "}, {:var, "item", [key: "name"]}, {:text, " ("},
-            {:var, "item", [key: "id"]}, {:text, ")\n  "}] == body
+    assert [{:newline, "\n"}, {:text, "    "}, {:var, "item", [key: "name"]}, {:text, " ("},
+            {:var, "item", [key: "id"]}, {:text, ")"}, {:newline, "\n"}, {:text, "  "}] == body
   end
 
   test "solo variables are parsed", context do
     {:ok, template} = Engine.parse(context.engine, Templates.solo_variable)
-    [{:text, "This is a test.\n\n"}, {:var, "item", nil}, {:text, ".\n"}] = template
+    [{:text, "This is a test."}, {:newline, "\n"}, {:newline, "\n"}, {:var, "item", nil}, {:text, "."}, {:newline, "\n"}] = template
   end
 
   test "comments w/o terminating newlines are parsed", context do
@@ -60,7 +58,7 @@ defmodule Greenbar.ParserTest do
     {:ok, template} = Engine.parse(context.engine, "~attachment title=\"This is a test\"~\n1 2 3\n~end~\n")
     assert [{:tag, "attachment",
              [{:assign_tag_attr, "title", {:string, 1, "This is a test"}}],
-             [text: "\n1 2 3\n"]}] === template
+             [{:text, "1 2 3"}, {:newline, "\n"}]}] === template
   end
 
 end

--- a/test/support/templates.ex
+++ b/test/support/templates.ex
@@ -177,13 +177,15 @@ No user creators available.
 ID: ~$results[0].id~
 Name: ~$results[0].name~
 
-Versions: ~each var=$results[0].versions~
+Versions:
+~each var=$results[0].versions~
 ~$item.version~
 ~end~
 
 # TODO: Think I need some 'if' tags here, too
 Enabled Version: ~$results[0].enabled_version.version~
-Relay Groups: ~each var=$results[0].relay_groups~
+Relay Groups:
+~each var=$results[0].relay_groups~
 ~$item.name~
 ~end~
 """


### PR DESCRIPTION
In the original issue for this issue, I wanted a way to simply define an if tag, but have the trailing newline not be emitted if the condition evaluated to false. Here's an example of what happened before:

Template:

```
Header
~if cond=true == false~Not printed~end~
~if cond=true == false~Printed~end~
Footer
```

Output:

```
Header

Printed
Footer
```

By tokenizing newlines and including them in the tag parsing rules, we can identify tags in which we can pull a trailing newline up into the body of the tag. This also applies nicely to other tags like `~each~` and `~attachments~`, making most tags now render newlines more intuitively.

This is the new output as you would expect:

```
Header
Printed
Footer
```

# Edge Cases

There are a few edge cases which I've mostly fixed but could still be an issue in the future for unusual templates.

* Subsequent tags that start with a newline but don't end with one can cause parsing to fail. This is mainly due to the fact that our parser can only lookahead one token, so once it's down the path of matching `newline tag` it can't backtrack once it's missing a newline at the end.

The following template will cause a parsing error:

```
~each var=$things~
~$item~
~end~ERROR
```

But, given that none of the templates in the tests for greenbar are written this way, I think it's safe to say that this is not a pattern used very often.

* Nested tags are a special case which are handled like the following:

Template:

```
~each var=$group as=group~
Group: ~$group.name~
~each var=$group.users as=user~
User: ~$user.name~
~end~
~end~
```

Output:

```
Group: Founders
User: Mark
User: Kevin
Group: Employees
User: Shelton
User: Matt
```

This breaks from what would happen in the naive case as there would be an extra newline between the two iterations from the outer each that render the groups.

* Join tags are a special case that don't include any newline injection to stay inline with past specs. 

Fixes https://github.com/operable/cog/issues/1266