### PR TITLE
Make join var global to avoid conflicts

### DIFF
--- a/lib/greenbar/tags/each.ex
+++ b/lib/greenbar/tags/each.ex
@@ -65,4 +65,3 @@ defmodule Greenbar.Tags.Each do
   end
 
 end
-

--- a/lib/greenbar/tags/join.ex
+++ b/lib/greenbar/tags/join.ex
@@ -52,19 +52,16 @@ defmodule Greenbar.Tags.Join do
                               {false, scope}
                           end
     joiner = get_attr(attrs, "with", ", ")
-    case get_remaining(scope, remaining_key, attrs) do
+    case get_remaining(scope, id, remaining_key, attrs) do
       nil ->
         {:halt, scope}
       [] ->
-        scope = scope
-        |> Scoped.erase(downstream_key)
-        |> Scoped.erase(remaining_key)
-        {:halt, scope}
+        {:halt, put(scope, id, remaining_key, [])}
       [h|t] ->
         var_name = get_attr(attrs, "as", "item")
         child_scope = new_scope(scope)
-        {:ok, child_scope} = Scoped.set(child_scope, var_name, h)
-        {:ok, scope} = set_remaining(scope, remaining_key, t)
+        child_scope = put(child_scope, :global, var_name, h)
+        scope = put(scope, id, remaining_key, t)
 
         output = if downstream do
           joiner
@@ -76,26 +73,17 @@ defmodule Greenbar.Tags.Join do
     end
   end
 
-  defp get_remaining(scope, key, attrs) do
-    case Scoped.lookup(scope, key) do
-      {:not_found, _} ->
+  defp get_remaining(scope, id, key, attrs) do
+    case get(scope, id, key) do
+      nil ->
         case get_attr(attrs, "var") do
           {:not_found, _} ->
             nil
           value ->
             value
         end
-      {:ok, value} ->
+      value ->
         value
-    end
-  end
-
-  defp set_remaining(scope, key, remaining) do
-    case Scoped.update(scope, key, remaining) do
-      {:not_found, _} ->
-        Scoped.set(scope, key, remaining)
-      {:ok, scope} ->
-        {:ok, scope}
     end
   end
 

--- a/test/eval_test.exs
+++ b/test/eval_test.exs
@@ -303,4 +303,29 @@ defmodule Greenbar.EvalTest do
                              name: :table_row}],
                         name: :table}]
   end
+
+  test "nested tags with conflicting vars", context do
+    template = """
+    ~each var=$results~
+    ~join var=$item.people with=", "~~$item.name~~end~
+    ~end~
+    """
+
+    data = %{
+      "results" => [%{
+        "people" => [
+          %{"name" => "Patrick"},
+          %{"name" => "Kevin"},
+          %{"name" => "Mark"},
+          %{"name" => "Shelton"}
+        ]
+      }]
+    }
+
+    actual = eval_template(context.engine, "nested_tags_with_conflicting_vars", template, data)
+
+    expected = [%{name: :paragraph, children: [%{name: :text, text: "Patrick, Kevin, Mark, Shelton"}]}]
+
+    assert expected == actual
+  end
 end

--- a/test/greenbar/tags/join_test.exs
+++ b/test/greenbar/tags/join_test.exs
@@ -50,6 +50,15 @@ defmodule Greenbar.Tags.JoinTest do
     assert [%{name: :paragraph, children: [%{name: :text, text: "highlander"}]}] == result
   end
 
+  test "join with empty input", context do
+    result = eval_template(context.engine,
+                           "join_with_one_input",
+                           "~join var=$stuff~~$item~~end~",
+                           %{"stuff" => []})
+
+    assert [] == result
+  end
+
   test "nested joins", context do
     result = eval_template(context.engine,
                            "nested",


### PR DESCRIPTION
To override the var set in an outer each tag, we need to correctly set
join vars as global in the child scope for the join tag body.