### PR TITLE
Fix author rendering in Slack attachments

### DIFF
--- a/lib/greenbar/renderers/slack.ex
+++ b/lib/greenbar/renderers/slack.ex
@@ -42,6 +42,7 @@ defmodule Greenbar.Renderers.SlackRenderer do
     end
     attachment
     |> rename_key("title_url", "title_link")
+    |> rename_key("author", "author_name")
     |> Map.delete("children")
     |> Map.put("text", attachment_text)
     |> Map.put("fallback", attachment_text)


### PR DESCRIPTION
Slack expects an `author_name` key, not `author`.