### PR TITLE
Update slack attachment

### DIFF
--- a/lib/greenbar/tags/attachment.ex
+++ b/lib/greenbar/tags/attachment.ex
@@ -32,6 +32,9 @@ defmodule Greenbar.Tags.Attachment do
     short: false}
   ```
 
+  When an attribute contains "-short" at the end (eg. `priority-short`), the `short` field will be set to `true`.
+  This flag indicates whether the value is short enough to be displayed side-by-side with other values.
+
   ## Example
 
   The template
@@ -149,10 +152,21 @@ defmodule Greenbar.Tags.Attachment do
     {Map.put(attachment, :ts, value), fields}
   end
   defp gen_attributes({key, value}, {attachment, fields}) do
-    field = %{title: key,
-              value: value,
-              short: false}
+    field = generate_field(key, value)
+
     {attachment, [field|fields]}
+  end
+  defp generate_field(key, value) do
+    field = %{value: value}
+
+    delimiter = "-short"
+    short = String.ends_with?(key, delimiter)
+    key = if short, do: String.trim_trailing(key, delimiter), else: key
+
+    field = Map.put(field, :title, key)
+    field = Map.put(field, :short, short)
+
+    field
   end
 
 end

--- a/lib/greenbar/tags/attachment.ex
+++ b/lib/greenbar/tags/attachment.ex
@@ -14,8 +14,14 @@ defmodule Greenbar.Tags.Attachment do
   * `color` -- Color to be used when rendering attachment (interpretation may vary by provider)
   * `image_url` -- Link to image asset (if any)
   * `author` -- Author name
+  * `author_icon` -- Author icon. Will only work if `author` is present
+  * `author_link` -- Use this to hyperlink author. Will only work if `author` is present
   * `pretext` -- Preamble text displayed before attachment body
+  * `fallback` -- A plain-text summary of the attachment to show in clients that don't show formatted text  (eg. IRC, mobile notifications)
+  * `thumb_url` -- Display a thumbnail on the right side of the message attachment
   * `footer` -- Brief text that appears as the attachment's footer
+  * `footer_icon` -- Footer icon. Will only work if `footer` is present
+  * `ts` -- Integer value in epoch time to show in `footer`.
 
   Any other attributes will be interpreted as custom fields and included in the attachments' `fields`
   field. Custom fields have the following structure:
@@ -112,17 +118,35 @@ defmodule Greenbar.Tags.Attachment do
   defp gen_attributes({"pretext", value}, {attachment, fields}) do
     {Map.put(attachment, :pretext, value), fields}
   end
+  defp gen_attributes({"fallback", value}, {attachment, fields}) do
+    {Map.put(attachment, :fallback, value), fields}
+  end
   defp gen_attributes({"color", value}, {attachment, fields}) do
     {Map.put(attachment, :color, value), fields}
   end
   defp gen_attributes({"image_url", value}, {attachment, fields}) do
     {Map.put(attachment, :image_url, value), fields}
   end
+  defp gen_attributes({"thumb_url", value}, {attachment, fields}) do
+    {Map.put(attachment, :thumb_url, value), fields}
+  end
   defp gen_attributes({"author", value}, {attachment, fields}) do
     {Map.put(attachment, :author, value), fields}
   end
+  defp gen_attributes({"author_link", value}, {attachment, fields}) do
+    {Map.put(attachment, :author_link, value), fields}
+  end
+  defp gen_attributes({"author_icon", value}, {attachment, fields}) do
+    {Map.put(attachment, :author_icon, value), fields}
+  end
   defp gen_attributes({"footer", value}, {attachment, fields}) do
     {Map.put(attachment, :footer, value), fields}
+  end
+  defp gen_attributes({"footer_icon", value}, {attachment, fields}) do
+    {Map.put(attachment, :footer_icon, value), fields}
+  end
+  defp gen_attributes({"ts", value}, {attachment, fields}) do
+    {Map.put(attachment, :ts, value), fields}
   end
   defp gen_attributes({key, value}, {attachment, fields}) do
     field = %{title: key,

--- a/test/greenbar/tags/attachment_test.exs
+++ b/test/greenbar/tags/attachment_test.exs
@@ -133,12 +133,13 @@ Displaying _~$thing~_
   test "attachment fields", context do
     [attachment|_] = eval_template(context.engine,
                                    "attachment_fields",
-                                   "~attachment title=title field1=Foo field2=\"Bar Baz\"~body~end~",
+                                   "~attachment title=title field1=Foo field2=\"Bar Baz\" field3-short=test~body~end~",
                                    %{})
 
     fields = Enum.sort(attachment.fields)
     expected = Enum.sort([%{title: "field1", value: "Foo", short: false},
-                          %{title: "field2", value: "Bar Baz", short: false}])
+                          %{title: "field2", value: "Bar Baz", short: false},
+                          %{title: "field3", value: "test", short: true}])
 
     assert fields == expected
   end

--- a/test/greenbar/tags/attachment_test.exs
+++ b/test/greenbar/tags/attachment_test.exs
@@ -105,7 +105,9 @@ Displaying _~$thing~_
   test "attachment attributes", context do
     result = eval_template(context.engine,
                            "attachment_attrs",
-                           "~attachment title=title title_url=title_url color=blue image_url=image_url author=author pretext=pretext~body~end~",
+                           "~attachment title=title title_url=title_url color=blue image_url=image_url\
+                           author=author fallback=fallback thumb_url=thumb_url pretext=pretext ts=ts\
+                           author_link=author_link author_icon=author_icon footer_icon=footer_icon~body~end~",
                            %{})
 
     assert [%{name: :attachment,
@@ -114,7 +116,13 @@ Displaying _~$thing~_
               color: "blue",
               image_url: "image_url",
               author: "author",
+              fallback: "fallback",
+              thumb_url: "thumb_url",
               pretext: "pretext",
+              ts: "ts",
+              author_link: "author_link",
+              author_icon: "author_icon",
+              footer_icon: "footer_icon",
               fields: [],
               children: [
                 %{name: :paragraph,


### PR DESCRIPTION
Hello. The first commit adds missing slack attachment attributes that have been added in the latest API (https://api.slack.com/docs/message-attachments).

The second commit is an optional one (not so clean interface) that gives support for toggling the
"short" attribute of the "fields" structure by searching for a special string at the end of an attribute (right now is "-short" but "-column" might be a better name).

Pick and choose. :)